### PR TITLE
Fix AppleWKWebViewEnvironmentRequestedEventArgs.DataStoreIdentifier

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSUUID.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSUUID.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Avalonia.Controls.Macios.Interop;
+
+internal class NSUUID : NSObject
+{
+    private static readonly IntPtr s_class = Libobjc.objc_getClass("NSUUID");
+    private static readonly IntPtr s_initWithUUIDBytes = Libobjc.sel_getUid("initWithUUIDBytes:");
+
+    private NSUUID() : base(s_class)
+    {
+    }
+
+    private NSUUID(IntPtr handle, bool owns) : base(handle, owns)
+    {
+    }
+
+    public static unsafe NSUUID Create(Guid value)
+    {
+        const int size = 16;
+        var buffer = stackalloc byte[size];
+        _ = value.TryWriteBytes(new Span<byte>(buffer, size));
+
+        var uuid = new NSUUID();
+        _ = Libobjc.intptr_objc_msgSend(uuid.Handle, s_initWithUUIDBytes, new IntPtr(buffer));
+        return uuid;
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKWebsiteDataStore.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKWebsiteDataStore.cs
@@ -16,9 +16,9 @@ internal class WKWebsiteDataStore(IntPtr handle, bool owns) : NSObject(handle, o
         new(Libobjc.intptr_objc_msgSend(s_class, s_defaultDataStore), false);
     public static WKWebsiteDataStore NonPersistent =>
         new(Libobjc.intptr_objc_msgSend(s_class, s_nonPersistentDataStore), false);
-    public static WKWebsiteDataStore ForIdentifier(string identifier)
+    public static WKWebsiteDataStore ForIdentifier(Guid identifier)
     {
-        using var nsIdentifier = NSString.Create(identifier);
+        using var nsIdentifier = NSUUID.Create(identifier);
         return new WKWebsiteDataStore(
             Libobjc.intptr_objc_msgSend(s_class, s_dataStoreForIdentifier, nsIdentifier.Handle), true);
     }

--- a/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
@@ -57,8 +57,9 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
         _config.WebsiteDataStore = (options.NonPersistentDataStore, options.DataStoreIdentifier) switch
         {
             (true, _) => WKWebsiteDataStore.NonPersistent,
-            (_, { Length: > 0 } id)
-                when OperatingSystem.IsIOSVersionAtLeast(17, 0) || OperatingSystem.IsMacOSVersionAtLeast(14, 0)
+            var (_, id)
+                when id != Guid.Empty && (OperatingSystem.IsIOSVersionAtLeast(17, 0) ||
+                                          OperatingSystem.IsMacOSVersionAtLeast(14, 0))
                 => WKWebsiteDataStore.ForIdentifier(id),
             _ => WKWebsiteDataStore.Default,
         };

--- a/src/Avalonia.Controls.WebView.Core/Platform/AppleWKWebViewEnvironmentRequestedEventArgs.cs
+++ b/src/Avalonia.Controls.WebView.Core/Platform/AppleWKWebViewEnvironmentRequestedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable once CheckNamespace
@@ -18,7 +19,7 @@ public sealed class AppleWKWebViewEnvironmentRequestedEventArgs : WebViewEnviron
     /// <summary>
     /// Gets or sets the unique identifier for a persistent data store object.
     /// </summary>
-    public string? DataStoreIdentifier { get; set; }
+    public Guid DataStoreIdentifier { get; set; }
 
     /// <summary>
     /// Gets or sets the application name that appears in the user agent string.


### PR DESCRIPTION
According to WebKit [document](https://developer.apple.com/documentation/webkit/wkwebsitedatastore/identifier) and [source code](https://github.com/WebKit/WebKit/blob/main/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm#L545), data store identifier should be UUID type, not string.