### PR TITLE
Fix NSUUID endianness

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSUUID.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSUUID.cs
@@ -19,7 +19,7 @@ internal class NSUUID : NSObject
     {
         const int size = 16;
         var buffer = stackalloc byte[size];
-        _ = value.TryWriteBytes(new Span<byte>(buffer, size));
+        _ = value.TryWriteBytes(new Span<byte>(buffer, size), true, out _);
 
         var uuid = new NSUUID();
         _ = Libobjc.intptr_objc_msgSend(uuid.Handle, s_initWithUUIDBytes, new IntPtr(buffer));


### PR DESCRIPTION
NSUUID use big endian, but the previous PR used little endian as encoding. Sorry for the mistake.