### PR TITLE
Fix WPEWebKit cookie operations

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Linux/Interop/WpeInterop.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/Interop/WpeInterop.cs
@@ -73,8 +73,14 @@ internal static unsafe partial class WpeInterop
     private const string LibWpeWebKit = "libWPEWebKit-2.0.so.1";
 
     [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_web_view_backend_get_type();
+    
+    [LibraryImport(LibWpeWebKit)]
     public static partial IntPtr webkit_web_view_backend_new(
         IntPtr viewBackend, IntPtr notifyFunc, IntPtr userData);
+
+    [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_web_view_get_type();
 
     [LibraryImport(LibWpeWebKit)]
     public static partial IntPtr webkit_web_view_new(IntPtr backend);
@@ -171,6 +177,9 @@ internal static unsafe partial class WpeInterop
 
     // Network session and cookie manager
     [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_network_session_get_type();
+
+    [LibraryImport(LibWpeWebKit)]
     public static partial IntPtr webkit_network_session_get_default();
 
     [LibraryImport(LibWpeWebKit, StringMarshalling = StringMarshalling.Utf8)]
@@ -212,6 +221,10 @@ internal static unsafe partial class WpeInterop
 
     private const string LibGObject = "libgobject-2.0.so.0";
     private const string LibGLib = "libglib-2.0.so.0";
+
+    [LibraryImport(LibGObject, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial IntPtr g_object_new_with_properties(IntPtr objType, uint nProperties, [In] string[] names,
+        [In] GValue[] values);
 
     [LibraryImport(LibGObject, StringMarshalling = StringMarshalling.Utf8)]
     public static partial ulong g_signal_connect_data(

--- a/src/Avalonia.Controls.WebView.Core/Linux/Interop/WpeStructs.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/Interop/WpeStructs.cs
@@ -119,3 +119,17 @@ internal struct WpeViewBackendExportableFdoClient
     public IntPtr Reserved0;
     public IntPtr Reserved1;
 }
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GValue
+{
+    public IntPtr Type;
+    public IntPtr Value0;
+    public IntPtr Value1;
+
+    public GValue(IntPtr type, IntPtr obj)
+    {
+        Type = type;
+        Value0 = obj;
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
@@ -812,11 +812,29 @@ internal sealed unsafe class WpeWebViewAdapter
             WpeInterop.soup_cookie_set_secure(soupCookie, cookie.Secure);
             WpeInterop.soup_cookie_set_http_only(soupCookie, cookie.HttpOnly);
 
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcsHandle = GCHandle.Alloc(tcs);
+
             WpeInterop.webkit_cookie_manager_add_cookie(
-                _cookieManager, soupCookie, IntPtr.Zero, null, IntPtr.Zero);
+                _cookieManager, soupCookie, IntPtr.Zero,
+                &OnAddCookieFinished, GCHandle.ToIntPtr(tcsHandle));
+
+            WaitForCompletion(tcs.Task);
 
             // soup cookie is consumed by webkit
         }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static void OnAddCookieFinished(IntPtr sourceObject, IntPtr result, IntPtr userData)
+    {
+        var tcsHandle = GCHandle.FromIntPtr(userData);
+        var tcs = (TaskCompletionSource<bool>)tcsHandle.Target!;
+        tcsHandle.Free();
+
+        IntPtr error = IntPtr.Zero;
+        var ok = WpeInterop.webkit_cookie_manager_add_cookie_finish(sourceObject, result, &error);
+        tcs.TrySetResult(ok && error == IntPtr.Zero);
     }
 
     public void DeleteCookie(string name, string domain, string path)
@@ -826,11 +844,45 @@ internal sealed unsafe class WpeWebViewAdapter
         var soupCookie = WpeInterop.soup_cookie_new(name, "", domain, path, 0);
         if (soupCookie != IntPtr.Zero)
         {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcsHandle = GCHandle.Alloc(tcs);
+
             WpeInterop.webkit_cookie_manager_delete_cookie(
-                _cookieManager, soupCookie, IntPtr.Zero, null, IntPtr.Zero);
+                _cookieManager, soupCookie, IntPtr.Zero,
+                &OnDeleteCookieFinished, GCHandle.ToIntPtr(tcsHandle));
+
+            WaitForCompletion(tcs.Task);
 
             WpeInterop.soup_cookie_free(soupCookie);
         }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static void OnDeleteCookieFinished(IntPtr sourceObject, IntPtr result, IntPtr userData)
+    {
+        var tcsHandle = GCHandle.FromIntPtr(userData);
+        var tcs = (TaskCompletionSource<bool>)tcsHandle.Target!;
+        tcsHandle.Free();
+
+        IntPtr error = IntPtr.Zero;
+        var ok = WpeInterop.webkit_cookie_manager_delete_cookie_finish(sourceObject, result, &error);
+        tcs.TrySetResult(ok && error == IntPtr.Zero);
+    }
+
+    private static void WaitForCompletion(Task task)
+    {
+        if (task.IsCompleted)
+        {
+            task.GetAwaiter().GetResult();
+            return;
+        }
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            WebViewDispatcher.PushFrameForTask(task);
+        }
+
+        task.GetAwaiter().GetResult();
     }
 
     public Task<IReadOnlyList<Cookie>> GetCookiesAsync()

--- a/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
@@ -241,7 +241,12 @@ internal sealed unsafe class WpeWebViewAdapter
         else
             _networkSession = WpeInterop.webkit_network_session_get_default();
 
-        _webView = WpeInterop.webkit_web_view_new(wkBackend);
+        var webViewType = WpeInterop.webkit_web_view_get_type();
+        var wkBackendType = WpeInterop.webkit_web_view_backend_get_type();
+        var networkSessionType = WpeInterop.webkit_network_session_get_type();
+        var keys = new[] { "backend", "network-session" };
+        var values = new[] { new GValue(wkBackendType, wkBackend), new GValue(networkSessionType, _networkSession) };
+        _webView = WpeInterop.g_object_new_with_properties(webViewType, 2, keys, values);
         if (_webView == IntPtr.Zero)
             throw new InvalidOperationException("webkit_web_view_new failed.");
 


### PR DESCRIPTION
What fixed:
- Wait async functions to complete
Add and delete operations are asynchronous; wait for them to complete.

- Bind network session to webview
Once the data or cache directory has been set, the WebView will not use the default network session.

Some consideration:
- Fix DeleteCookie
Due to a [limitation in libsoup](https://gitlab.gnome.org/GNOME/libsoup/-/issues/520), the current interface cannot delete cookies based on a specified name, domain, and path, without cookie value. I propose adding a new method `void DeleteCookie(Cookie cookie)`.