### PR TITLE
Expose macOS WKScriptMessageHandler name via ScriptHandlerMessageName

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
@@ -20,9 +20,10 @@ namespace Avalonia.Controls.Macios;
 internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterWithInputRedirect,
     IWebViewAdapterWithCookieManager, IWebViewAdapterWithCommands, IWebViewWithPrint, IAppleWKWebViewPlatformHandle
 {
-    private const string PostAvWebViewMessageName = "postAvWebViewMessage";
+    private const string DefaultPostAvWebViewMessageName = "postAvWebViewMessage";
 
-    private readonly NSString _postAvWebViewMessageName = NSString.Create(PostAvWebViewMessageName);
+    private readonly string _scriptHandlerMessageName;
+    private readonly NSString _scriptHandlerMessageNameNative;
     private readonly WKWebViewConfiguration _config;
     private readonly WKWebView _webView;
     private readonly WKNavigationDelegate _navDelegate;
@@ -33,8 +34,10 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
         _scriptHandler = new WKScriptMessageHandler();
         _scriptHandler.DidReceiveScriptMessage += OnScriptHandlerOnDidReceiveScriptMessage;
 
+        _scriptHandlerMessageName = options.ScriptHandlerMessageName ?? DefaultPostAvWebViewMessageName;
+        _scriptHandlerMessageNameNative = NSString.Create(_scriptHandlerMessageName);
         _config = new WKWebViewConfiguration { JavaScriptEnabled = true };
-        _config.AddScriptMessageHandler(_scriptHandler, _postAvWebViewMessageName);
+        _config.AddScriptMessageHandler(_scriptHandler, _scriptHandlerMessageNameNative);
 
         if (options.ApplicationNameForUserAgent is not null)
         {
@@ -204,7 +207,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
         _webView.BecomeFirstResponder -= OnWebViewOnBecomeFirstResponder;
         _webView.ResignFirstResponder -= OnWebViewOnResignFirstResponder;
 
-        _config.RemoveScriptMessageHandler(_postAvWebViewMessageName);
+        _config.RemoveScriptMessageHandler(_scriptHandlerMessageNameNative);
         _webView.NavigationDelegate = null;
         _webView.LoadRequest(null);
 
@@ -239,7 +242,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
 
     private async void OnScriptHandlerOnDidReceiveScriptMessage(object? sender, WKScriptMessageHandler.ScriptMessageEventArgs args)
     {
-        if (args.Name == PostAvWebViewMessageName)
+        if (args.Name == _scriptHandlerMessageName)
         {
             var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
             var state = new WKWebView.JSCallState(_webView.Handle, tcs);
@@ -288,7 +291,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
 
     private async void OnDelegateOnDidFinishNavigation(object? sender, EventArgs args)
     {
-        _ = await InvokeScript($"function invokeCSharpAction(data){{window.webkit.messageHandlers.{PostAvWebViewMessageName}.postMessage(data);}}");
+        _ = await InvokeScript($"function invokeCSharpAction(data){{window.webkit.messageHandlers.{_scriptHandlerMessageName}.postMessage(data);}}");
 
         using var url = _webView.Url;
         NavigationCompleted?.Invoke(this, new WebViewNavigationCompletedEventArgs { Request = Uri.TryCreate(url!.AbsoluteString, UriKind.Absolute, out var uri) ? uri : null, IsSuccess = true });

--- a/src/Avalonia.Controls.WebView.Core/Platform/AppleWKWebViewEnvironmentRequestedEventArgs.cs
+++ b/src/Avalonia.Controls.WebView.Core/Platform/AppleWKWebViewEnvironmentRequestedEventArgs.cs
@@ -35,4 +35,9 @@ public sealed class AppleWKWebViewEnvironmentRequestedEventArgs : WebViewEnviron
     /// Gets or sets a value indicating whether the web view limits navigation to pages within the application's domain.
     /// </summary>
     public bool LimitsNavigationsToAppBoundDomains { get; set; } = false;
+    
+    /// <summary>
+    /// Gets or sets the name of the script message handler.
+    /// </summary>
+    public string? ScriptHandlerMessageName { get; set; }  
 }


### PR DESCRIPTION
## Summary
  Adds an optional `ScriptHandlerMessageName` to `AppleWKWebViewEnvironmentRequestedEventArgs`, letting consumers configure the `WKScriptMessageHandler` name used by the macOS / iOS `WebView`. When unset, the existing `postAvWebViewMessage` default is preserved, so behavior is unchanged  
  for current callers.                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                 
  Fixes #34.                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                               
  ## Motivation                                                                                                                                                                                                                                                                                  
  Applications that already embed a JS bridge over `window.webkit.messageHandlers.<name>.postMessage(...)` can't reuse their web-side code with Avalonia today, because the handler name is hard-coded. Making it configurable allows those apps to migrate to Avalonia without rewriting the
  JavaScript side.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                               
  ## Changes                                                                                                                                                                                                                                                                                     
  - `AppleWKWebViewEnvironmentRequestedEventArgs`: new nullable `ScriptHandlerMessageName` property.                                                                                                                                                                                           
  - `MaciosWebViewAdapter`: replaces the `PostAvWebViewMessageName` constant with the configured value (falling back to the previous default), and threads it through script-handler registration / removal, the `DidReceiveScriptMessage` dispatch, and the `invokeCSharpAction` JS shim emitted
   on navigation completion.                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                 
  ## Notes                                                                                                                                                                                                                                                                                       
  - macOS / iOS only — Windows and Linux backends are untouched.                                                                                                                                                                                                                               
  - Purely additive and backward-compatible.
  - The issue suggested the name `WebViewMessageName`; I went with `ScriptHandlerMessageName` because it more directly reflects that it sets the name of the underlying `WKScriptMessageHandler`. Happy to rename if maintainers prefer the original.                                            
                                                                                                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                                                                                                   
  - [ ] Default behavior: with `ScriptHandlerMessageName` unset, `window.webkit.messageHandlers.postAvWebViewMessage.postMessage(...)` still reaches managed code.                                                                                                                               
  - [ ] Custom name: setting `ScriptHandlerMessageName = "myBridge"` makes `window.webkit.messageHandlers.myBridge.postMessage(...)` reach managed code, and the default name no longer resolves.