### PR TITLE
Fix Linux WebView first-paint and Wayland-session GTK init (#5)

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Gtk/AvaloniaGtk.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/AvaloniaGtk.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Controls.Linux.Interop;
 using Avalonia.Logging;
 
 namespace Avalonia.Controls.Gtk;
@@ -109,9 +110,16 @@ internal static partial class AvaloniaGtk
                 if (current is { Length: > 0 } && !string.Equals(current, "wayland", StringComparison.Ordinal))
                     return EmptyScope.Instance;
 
-                try { setenv("GDK_BACKEND", "x11", 1); }
+                int rc;
+                try { rc = LibC.setenv("GDK_BACKEND", "x11", 1); }
                 catch (DllNotFoundException) { return EmptyScope.Instance; }
                 catch (EntryPointNotFoundException) { return EmptyScope.Instance; }
+                if (rc != 0)
+                {
+                    Logger.TryGet(LogEventLevel.Warning, "WebView")?.Log(null,
+                        "libc setenv(GDK_BACKEND, x11) returned {Rc}; gtk_init may still pick Wayland", rc);
+                    return EmptyScope.Instance;
+                }
                 Environment.SetEnvironmentVariable("GDK_BACKEND", "x11");
                 s_savedBackend = current;
             }
@@ -123,12 +131,6 @@ internal static partial class AvaloniaGtk
     private static readonly object s_overrideLock = new();
     private static int s_overrideCount;
     private static string? s_savedBackend;
-
-    [LibraryImport("libc", EntryPoint = "setenv", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial int setenv(string name, string value, int overwrite);
-
-    [LibraryImport("libc", EntryPoint = "unsetenv", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial int unsetenv(string name);
 
     private sealed class EmptyScope : IDisposable
     {
@@ -152,9 +154,9 @@ internal static partial class AvaloniaGtk
                 try
                 {
                     if (previous is null)
-                        unsetenv("GDK_BACKEND");
+                        LibC.unsetenv("GDK_BACKEND");
                     else
-                        setenv("GDK_BACKEND", previous, 1);
+                        LibC.setenv("GDK_BACKEND", previous, 1);
                 }
                 catch (DllNotFoundException) { }
                 catch (EntryPointNotFoundException) { }

--- a/src/Avalonia.Controls.WebView.Core/Gtk/AvaloniaGtk.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/AvaloniaGtk.cs
@@ -6,12 +6,13 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Logging;
 
 namespace Avalonia.Controls.Gtk;
 
-internal static class AvaloniaGtk
+internal static partial class AvaloniaGtk
 {
     static AvaloniaGtk()
     {
@@ -62,6 +63,105 @@ internal static class AvaloniaGtk
     }
 
     public static bool HasSoup3 { get; }
+
+    /// <summary>
+    /// Ensures GDK_BACKEND=x11 is in effect for the duration of the bridge call that
+    /// initializes GTK in Avalonia.X11.NativeDialogs.Gtk. The X11 GTK adapters in this
+    /// package use X11/GDK-X11-only entry points and require the X11 GDK backend; under
+    /// a Wayland session GDK_BACKEND is typically pre-set to "wayland" by the desktop,
+    /// which would otherwise cause `gtk_init` to fail with "Unable to initialize GTK".
+    /// </summary>
+    /// <remarks>
+    /// Only overrides the unset case and the implicit "wayland" case (the default under
+    /// a Wayland session). If the user has explicitly set some other backend like
+    /// "broadway", that's a deliberate choice in conflict with loading an X11-only
+    /// adapter, and we let `gtk_init` fail with its own error rather than silently
+    /// override.
+    ///
+    /// `Environment.SetEnvironmentVariable` alone is insufficient on Linux — it updates
+    /// the .NET managed env cache but does not propagate to libc's environ, which is
+    /// what `gtk_init` reads via `getenv`. A direct libc `setenv` call is required.
+    ///
+    /// The returned IDisposable restores the previous env value on Dispose. By that
+    /// point GTK has already locked in its backend choice for the process, so restoring
+    /// the env doesn't switch backends — it just keeps the rest of the process's env
+    /// state clean for any unrelated code that reads GDK_BACKEND.
+    ///
+    /// Concurrent calls share a single override window via refcounting: the first call
+    /// captures the previous env value and applies the override, subsequent overlapping
+    /// calls only refcount, and the override is restored when the last scope is
+    /// disposed. Without refcounting, two concurrent CreateBuilder calls could each
+    /// snapshot the other's already-overridden value and leave the env stuck at "x11"
+    /// after both restore.
+    /// </remarks>
+    public static IDisposable EnsureX11GdkBackendForGtkInit()
+    {
+        if (!OperatingSystem.IsLinux())
+            return EmptyScope.Instance;
+
+        lock (s_overrideLock)
+        {
+            if (s_overrideCount == 0)
+            {
+                var current = Environment.GetEnvironmentVariable("GDK_BACKEND");
+                if (string.Equals(current, "x11", StringComparison.Ordinal))
+                    return EmptyScope.Instance;
+                if (current is { Length: > 0 } && !string.Equals(current, "wayland", StringComparison.Ordinal))
+                    return EmptyScope.Instance;
+
+                try { setenv("GDK_BACKEND", "x11", 1); }
+                catch (DllNotFoundException) { return EmptyScope.Instance; }
+                catch (EntryPointNotFoundException) { return EmptyScope.Instance; }
+                Environment.SetEnvironmentVariable("GDK_BACKEND", "x11");
+                s_savedBackend = current;
+            }
+            s_overrideCount++;
+        }
+        return new RestoreGdkBackendScope();
+    }
+
+    private static readonly object s_overrideLock = new();
+    private static int s_overrideCount;
+    private static string? s_savedBackend;
+
+    [LibraryImport("libc", EntryPoint = "setenv", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int setenv(string name, string value, int overwrite);
+
+    [LibraryImport("libc", EntryPoint = "unsetenv", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int unsetenv(string name);
+
+    private sealed class EmptyScope : IDisposable
+    {
+        public static readonly EmptyScope Instance = new();
+        public void Dispose() { }
+    }
+
+    private sealed class RestoreGdkBackendScope : IDisposable
+    {
+        private int _disposed;
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+            lock (s_overrideLock)
+            {
+                if (--s_overrideCount > 0)
+                    return;
+                var previous = s_savedBackend;
+                s_savedBackend = null;
+                try
+                {
+                    if (previous is null)
+                        unsetenv("GDK_BACKEND");
+                    else
+                        setenv("GDK_BACKEND", previous, 1);
+                }
+                catch (DllNotFoundException) { }
+                catch (EntryPointNotFoundException) { }
+                Environment.SetEnvironmentVariable("GDK_BACKEND", previous);
+            }
+        }
+    }
 
     public static Version? TryGetVersion()
     {

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenAvaloniaWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenAvaloniaWebViewAdapter.cs
@@ -34,6 +34,7 @@ internal sealed class GtkOffscreenAvaloniaWebViewAdapter : GtkOffscreenWebViewAd
     public static async Task<WebViewAdapter.OffscreenWebViewAdapterBuilder> CreateBuilder(
         GtkWebViewEnvironmentRequestedEventArgs environmentArgs)
     {
+        using var _ = EnsureX11GdkBackendForGtkInit();
         var adapter = await RunOnGlibThreadAsync(() => new GtkOffscreenAvaloniaWebViewAdapter(environmentArgs));
         return (parent) =>
         {

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkX11WebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkX11WebViewAdapter.cs
@@ -28,6 +28,7 @@ internal sealed class GtkX11WebViewAdapter : GtkWebViewAdapter, IPlatformHandle
     public static async Task<WebViewAdapter.NativeWebViewAdapterBuilder> CreateBuilder(
         GtkWebViewEnvironmentRequestedEventArgs environmentArgs)
     {
+        using var _ = EnsureX11GdkBackendForGtkInit();
         var adapter = await RunOnGlibThreadAsync(() => new GtkX11WebViewAdapter(environmentArgs));
         return (parent, _) =>
         {

--- a/src/Avalonia.Controls.WebView.Core/Linux/Interop/LibC.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/Interop/LibC.cs
@@ -10,6 +10,14 @@ internal static unsafe partial class LibC
     [LibraryImport("libc", StringMarshalling = StringMarshalling.Utf8)]
     public static partial int setenv(string name, string value, int overwrite);
 
+    [LibraryImport("libc", StringMarshalling = StringMarshalling.Utf8)]
+    public static partial int unsetenv(string name);
+
+    // libc owns the returned buffer — never free it. nint return keeps the
+    // ownership semantics explicit; callers convert with Marshal.PtrToStringUTF8.
+    [LibraryImport("libc", StringMarshalling = StringMarshalling.Utf8)]
+    public static partial nint getenv(string name);
+
     [LibraryImport("libc")]
     public static partial int poll(GPollFD* fds, nint nfds, int timeout);
 

--- a/src/Avalonia.Controls.WebView/NativeWebView.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebView.cs
@@ -466,6 +466,12 @@ namespace Avalonia.Xpf.Controls
 
 #if AVALONIA
             VisualChildren.Add((Control)controlHostImpl);
+            // VisualChildren.Add doesn't itself invalidate layout. Without an explicit
+            // invalidation here, MeasureOverride/ArrangeOverride below are never called
+            // for the freshly added child, its Bounds stay default(Rect), and the X11
+            // INativeControlHostImpl never gets non-zero bounds to map its slot at
+            // (the symptom in https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/5).
+            InvalidateMeasure();
 #elif WPF
             IsVisibleChanged += OnIsVisibleChanged;
             var visual = (System.Windows.Media.Visual)controlHostImpl;
@@ -507,15 +513,45 @@ namespace Avalonia.Xpf.Controls
             // Also WPF doesn't have an equivalent.
             // Keeping this hack makes some sort of a compromise, where on Ava 11.3 we have this property and and potentially reset by user if needed.
             var measured = base.MeasureOverride(availableSize);
+
+            ControlSize resolved;
 #if AVALONIA
             if (s_setSizing is not null)
-                return measured;
+                resolved = measured;
+            else
+#endif
+                resolved = new ControlSize(
+                    double.IsInfinity(availableSize.Width) ? measured.Width : availableSize.Width,
+                    double.IsInfinity(availableSize.Height) ? measured.Height : availableSize.Height);
+
+#if AVALONIA
+            // controlHostImpl is added via VisualChildren.Add, which does NOT make it a
+            // layout participant — Avalonia only measures/arranges visual children that
+            // the parent explicitly drives. Without this, the inner NativeControlHost's
+            // Bounds stay default(Rect) and the X11 INativeControlHostImpl never maps
+            // its slot. See issue #5 / PR #38.
+            foreach (var child in VisualChildren)
+            {
+                if (child is global::Avalonia.Layout.Layoutable layoutable)
+                    layoutable.Measure(resolved);
+            }
 #endif
 
-            return new ControlSize(
-                double.IsInfinity(availableSize.Width) ? measured.Width : availableSize.Width,
-                double.IsInfinity(availableSize.Height) ? measured.Height : availableSize.Height);
+            return resolved;
         }
+
+#if AVALONIA
+        protected override ControlSize ArrangeOverride(ControlSize finalSize)
+        {
+            var arranged = base.ArrangeOverride(finalSize);
+            foreach (var child in VisualChildren)
+            {
+                if (child is global::Avalonia.Layout.Layoutable layoutable)
+                    layoutable.Arrange(new global::Avalonia.Rect(arranged));
+            }
+            return arranged;
+        }
+#endif
 
         private void WithFocusOnLostFocus(object? sender, Core.IWebViewAdapterWithFocus.LostFocusDirection e)
         {

--- a/src/Avalonia.Controls.WebView/NativeWebView.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebView.cs
@@ -529,7 +529,7 @@ namespace Avalonia.Xpf.Controls
             // layout participant — Avalonia only measures/arranges visual children that
             // the parent explicitly drives. Without this, the inner NativeControlHost's
             // Bounds stay default(Rect) and the X11 INativeControlHostImpl never maps
-            // its slot. See issue #5 / PR #38.
+            // its slot (symptom: blank pane on Linux until the user resizes the window).
             foreach (var child in VisualChildren)
             {
                 if (child is global::Avalonia.Layout.Layoutable layoutable)

--- a/tests/Avalonia.Controls.WebView.Tests/GdkBackendOverrideTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/GdkBackendOverrideTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia.Controls.Gtk;
+using Avalonia.Controls.Linux.Interop;
+using Xunit;
+
+namespace Avalonia.Controls.WebView.Tests;
+
+public class GdkBackendOverrideTests
+{
+    private const string EnvVar = "GDK_BACKEND";
+
+    [Fact]
+    public void Wayland_Is_Overridden_And_Restored()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Linux-only: exercises libc setenv/getenv");
+
+        using var _ = SaveEnv();
+        SetEnv("wayland");
+
+        using (var scope = AvaloniaGtk.EnsureX11GdkBackendForGtkInit())
+        {
+            AssertEnv("x11");
+        }
+
+        AssertEnv("wayland");
+    }
+
+    [Fact]
+    public void Unset_Is_Overridden_And_Restored_To_Unset()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Linux-only: exercises libc setenv/getenv");
+
+        using var _ = SaveEnv();
+        SetEnv(null);
+
+        using (var scope = AvaloniaGtk.EnsureX11GdkBackendForGtkInit())
+        {
+            AssertEnv("x11");
+        }
+
+        AssertEnv(null);
+    }
+
+    [Fact]
+    public void Already_X11_Is_NoOp()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Linux-only: exercises libc setenv/getenv");
+
+        using var _ = SaveEnv();
+        SetEnv("x11");
+
+        using (var scope = AvaloniaGtk.EnsureX11GdkBackendForGtkInit())
+        {
+            AssertEnv("x11");
+        }
+
+        AssertEnv("x11");
+    }
+
+    [Fact]
+    public void Explicit_Other_Backend_Is_Not_Overridden()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Linux-only: exercises libc setenv/getenv");
+
+        using var _ = SaveEnv();
+        SetEnv("broadway");
+
+        using (var scope = AvaloniaGtk.EnsureX11GdkBackendForGtkInit())
+        {
+            AssertEnv("broadway");
+        }
+
+        AssertEnv("broadway");
+    }
+
+    [Fact]
+    public void Nested_Scopes_Restore_Only_On_Last_Dispose()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Linux-only: exercises libc setenv/getenv");
+
+        using var _ = SaveEnv();
+        SetEnv("wayland");
+
+        using (var outer = AvaloniaGtk.EnsureX11GdkBackendForGtkInit())
+        {
+            AssertEnv("x11");
+
+            using (var inner = AvaloniaGtk.EnsureX11GdkBackendForGtkInit())
+            {
+                AssertEnv("x11");
+            }
+
+            // outer still active — must not have restored yet
+            AssertEnv("x11");
+        }
+
+        AssertEnv("wayland");
+    }
+
+    private static void SetEnv(string? value)
+    {
+        if (value is null)
+            LibC.unsetenv(EnvVar);
+        else
+            LibC.setenv(EnvVar, value, 1);
+        Environment.SetEnvironmentVariable(EnvVar, value);
+    }
+
+    private static string? GetLibCEnv(string name)
+    {
+        var ptr = LibC.getenv(name);
+        return ptr == 0 ? null : Marshal.PtrToStringUTF8(ptr);
+    }
+
+    // Asserts both the managed env cache AND libc's environ — the latter is
+    // what gtk_init reads via getenv, so it's the layer that actually decides
+    // whether the override is effective.
+    private static void AssertEnv(string? expected)
+    {
+        Assert.Equal(expected, Environment.GetEnvironmentVariable(EnvVar));
+        Assert.Equal(expected, GetLibCEnv(EnvVar));
+    }
+
+    private static IDisposable SaveEnv()
+    {
+        var original = Environment.GetEnvironmentVariable(EnvVar);
+        return new RestoreOnDispose(() => SetEnv(original));
+    }
+
+    private sealed class RestoreOnDispose(Action action) : IDisposable
+    {
+        public void Dispose() => action();
+    }
+}


### PR DESCRIPTION
Contributes to #5.

Two related fixes for the same broken-on-Linux symptom in the GTK adapters. Each can be discussed independently if you'd prefer them split — happy to break this into two PRs.

---

## 1. First-paint blank pane on Linux

### Symptom

`NativeWebView` loads adapters cleanly on Linux — `installed=True`, `AdapterCreated handle=XID`, `NavigationCompleted ok=True` — but paints zero pixels until the user resizes the window. Setting a coloured `Background` doesn't tint either.

### Root cause

`NativeWebView` constructs an internal `NativeWebViewControlHost` (an Avalonia `NativeControlHost`) and adds it via `VisualChildren.Add`. Adding to `VisualChildren` makes a control a visual descendant but **not** a layout participant — Avalonia only measures and arranges children the parent explicitly drives. The base `MeasureOverride` returned size based on the requested control size but didn't measure its visual children, and there was no `ArrangeOverride` at all.

Cascading consequence:

- `controlHostImpl.Bounds` stays `default(Rect)` (its `Measure`/`Arrange` are never called).
- The bounds-zero guard inside `NativeControlHost.TryUpdateNativeControlPosition` bails (a zero-size slot isn't worth committing to the platform).
- `INativeControlHostImpl.ShowInBounds` is never called.
- On X11 specifically, the slot is created sized 1×1 and `IsUnMapped`. After `GtkX11WebViewAdapter.SetParent` reparents the GTK toplevel under that slot, `xwininfo` shows:

| layer | size | map state |
|---|---|---|
| Avalonia toplevel | (window size) | IsViewable |
| Native-host slot  | **1×1** | **IsUnMapped** |
| Reparented GTK toplevel | 200×200 (GTK default) | **IsUnviewable** |

The slot's descendants are `IsUnviewable` per X11 semantics — an ancestor isn't mapped, so even a correctly-rendering WebKit surface inside it has nowhere to reach the screen.

A user-driven resize happens to trigger a full layout pass that *does* propagate bounds into the slot, maps it, and the size-sync wiring takes over for the lifetime of the control — hence "blank until I resize the window". The size-sync wiring isn't broken; the host's children were never driven through layout in the first place. Avalonia's X11 `INativeControlHostImpl` is fine.

### Fix

Drive `Measure` and `Arrange` over `VisualChildren` explicitly inside `NativeWebView.MeasureOverride` / `ArrangeOverride`. With this wiring, `controlHostImpl.Bounds` is populated on first layout, the bounds-zero guard passes, and `ShowInBounds` maps the slot at the correct size on first show.

```csharp
protected override ControlSize MeasureOverride(ControlSize availableSize)
{
    var measured = base.MeasureOverride(availableSize);
    var resolved = /* existing sizing logic */;

    foreach (var child in VisualChildren)
    {
        if (child is Layoutable layoutable)
            layoutable.Measure(resolved);
    }

    return resolved;
}

protected override ControlSize ArrangeOverride(ControlSize finalSize)
{
    var arranged = base.ArrangeOverride(finalSize);
    foreach (var child in VisualChildren)
    {
        if (child is Layoutable layoutable)
            layoutable.Arrange(new Rect(arranged));
    }
    return arranged;
}
```

Gated to the Avalonia code path via `#if AVALONIA` so WPF / XPF stay untouched. The wiring runs on all Avalonia platforms but only changes observable behavior on Linux — Windows / macOS / Android were driving layout correctly through other paths and continue to. No Avalonia core changes needed.

---

## 2. Force `GDK_BACKEND=x11` around GTK init

### Symptom

Under a Wayland session (e.g. KDE Plasma 6 Wayland, default GNOME on most distros) `GDK_BACKEND` is pre-set to `wayland` by the desktop. With the package as-is, Avalonia's GTK bridge (`Avalonia.X11.NativeDialogs.Gtk.StartGtk`) consequently picks the Wayland backend and `gtk_init` fails:

```
System.InvalidOperationException: Unable to initialize GTK
   at Avalonia.Controls.Gtk.AvaloniaGtk.<RunTask>g__PrivateApi|12_0[T](...)
   at Avalonia.Controls.Gtk.GtkX11WebViewAdapter.CreateBuilder(...)
```

Both `GtkX11WebViewAdapter` and `GtkOffscreenAvaloniaWebViewAdapter` go through the same bridge and both rely on X11/GDK-X11-only entry points, so the failure mode is shared. Consumers had to set `GDK_BACKEND=x11` in the shell before launching, which is awkward to document for an end-user app.

### Fix

Add a shared helper `AvaloniaGtk.EnsureX11GdkBackendForGtkInit()` and use it via `using var _ = ...` at the top of each adapter's `CreateBuilder`:

```csharp
public static async Task<...> CreateBuilder(...)
{
    using var _ = EnsureX11GdkBackendForGtkInit();
    var adapter = await RunOnGlibThreadAsync(() => new ...);
    // ...
}
```

Properties of the helper:

- **Scoped via IDisposable.** The override only persists for the duration of the bridge call. By the time `CreateBuilder` returns, `GDK_BACKEND` is back to its original value. GTK has already locked in the X11 backend for the process by then, so restoring doesn't switch backends — it just keeps the process env clean for any unrelated code that reads `GDK_BACKEND`.

- **Conservative about user intent.** Only overrides the unset case and the implicit `"wayland"` case (the default under a Wayland session). If the user has explicitly set some other backend like `"broadway"`, that's a deliberate choice in conflict with loading an X11-only adapter, and we let `gtk_init` fail with its own error rather than silently override. The unset / implicit-wayland path is the no-decision case where the override is unambiguously what the consumer wants.

- **Uses libc `setenv` directly via P/Invoke.** `Environment.SetEnvironmentVariable` is **not sufficient** on Linux: it updates .NET's managed env cache but does not propagate to libc's `environ`, which is what `gtk_init` reads via `getenv`. Verified empirically — setting it via `Environment.SetEnvironmentVariable` from `Program.Main` left `gtk_init` still failing despite the managed cache reading `x11`. A direct libc `setenv` call (routed through the existing `Avalonia.Controls.Linux.Interop.LibC`) is what actually takes effect.

`gdk_set_allowed_backends` was attempted first as the GTK-blessed alternative but did not constrain Avalonia's GTK init helper in practice — the call returned cleanly and `gtk_init` continued to pick Wayland. The `setenv` route was the only one that worked end-to-end. (Happy to switch to the GTK API if a reviewer can identify why it didn't take effect.)

`DllNotFoundException` / `EntryPointNotFoundException` are swallowed defensively in case a future Linux runtime ships without a libc binding under that exact name. A non-zero `setenv` return is also treated as a bail-out, logged via `Avalonia.Logging`, so managed and native env state can't diverge.

---

## Testing

Verified on two mainstream Linux configurations using a minimal Avalonia 12 standalone repro app (single `NativeWebView`, hard-coded red `<body>` test page) with no consumer-side workarounds in the picture:

| | dev box | cross-check |
|---|---|---|
| OS | KDE Neon 24.04 | Arch Linux |
| compositor | KWin / **X11** | KWin / **Wayland session, XWayland for X11** |
| KDE Plasma | 5 | 6 |
| `webkit2gtk-4.1` | 2.50.1 | 2.52.3 |
| `.NET` | 10.0.103 | 10.0.104 |
| stock 12.0.0 (no fixes) | blank pane, slot 1×1 IsUnMapped, GTK 200×200 IsUnviewable | same — bug reproduces, and Wayland session also blocks adapter init via `GDK_BACKEND` |
| with this PR | red paints first show, slot WxH IsViewable, GTK matches, no `GDK_BACKEND=x11` needed | same — both fixes work |

Two divergent platforms (Plasma 5 X11-native and Plasma 6 Wayland-via-XWayland, two `webkit2gtk-4.1` minor versions apart) both go from blank → red with only the package change. Same bug signature, same fix outcome.

A *Wayland-native* Avalonia run (no XWayland) wasn't tested — both Linux GTK adapters in this package are X11-only by construction, so that's a different code path / different fix discussion.

The `GDK_BACKEND` override / refcount logic is also covered by `GdkBackendOverrideTests` (5 facts, Linux-only). Each assertion checks both the managed env cache and libc's `environ` via `getenv`, so a silent libc no-op — the actual failure mode that motivated the libc P/Invoke — would fail the test rather than pass at the managed layer.

## Anything else

- The first-paint fix lives in `NativeWebView` rather than a specific X11 adapter, so it benefits any future native-host-backed adapter, not just the current one.
- The `EnsureX11GdkBackendForGtkInit` helper is Linux-only and shared between the X11 and offscreen adapters so they can't drift; both get the fix from a single source.
