### PR TITLE
Fix WebView2 MoveFocus crash on window activation (issue #27)

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
@@ -245,10 +245,43 @@ internal abstract partial class WebView2BaseAdapter(ICoreWebView2Controller cont
 
     public void Focus()
     {
-        controller.MoveFocus(0 /* Programmatic */);
+        SafeCallController(() =>
+            controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON.COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC));
     }
 
     public void ResignFocus() { }
+
+    private void SafeCallController(Action action)
+    {
+        if (Disposed || controller == null)
+        {
+            return;
+        }
+        try
+        {
+            action();
+        }
+        catch (ArgumentException ex) when (ex.HResult == HResult.EInvalidArg)
+        {
+            // Controller rejected MoveFocus with E_INVALIDARG — transient state during
+            // async init or window-activation race. Safe to ignore; focus re-establishes
+            // naturally once the controller reaches a ready state.
+        }
+        catch (COMException ex) when (ex.HResult is HResult.EInvalidArg or HResult.EInvalidState)
+        {
+            // Same transient rejection surfaced as COMException depending on the
+            // source-generated interop path (e.g. during controller teardown).
+        }
+    }
+
+    private static class HResult
+    {
+        // E_INVALIDARG (0x80070057): returned by MoveFocus when the controller rejects
+        // the call during async init or window-activation races.
+        public const int EInvalidArg = unchecked((int)0x80070057);
+        // ERROR_INVALID_STATE (0x8007139F): observed in teardown-phase rejections.
+        public const int EInvalidState = unchecked((int)0x8007139F);
+    }
 
     internal EventHandler<WebViewNavigationStartingEventArgs>? GetNavigationStarted() => NavigationStarted;
     internal EventHandler<WebViewNavigationCompletedEventArgs>? GetNavigationCompleted() => NavigationCompleted;

--- a/tests/Avalonia.Controls.WebView.Tests/WebView2BaseAdapterTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/WebView2BaseAdapterTests.cs
@@ -1,0 +1,74 @@
+#pragma warning disable CA1416 // Platform compatibility — guarded by runtime OS check inside each test
+
+using System;
+using System.Runtime.InteropServices;
+using Avalonia.Controls.Win;
+using Avalonia.Controls.Win.WebView2;
+using Avalonia.Controls.Win.WebView2.Interop;
+using Xunit;
+
+namespace Avalonia.Controls.WebView.Tests;
+
+public class WebView2BaseAdapterTests
+{
+    // Reproduces https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/27
+    // The controller exists but rejects MoveFocus with E_INVALIDARG during a
+    // window-activation race (WM_ACTIVATE fires before async init completes).
+    // This tests that the adapter's Focus method doesn't throw in this scenario, which would cause a crash at runtime.
+    // NOTE: This is a regression test for a specific issue. We test the implementation by faking the behavior
+    // of the controller, rather than using a real WebView2 instance, to avoid the complexity of reproducing the exact race
+    // condition in a reliable way.
+    [Fact]
+    public void FocusShouldNotThrowWhenControllerThrowsEInvalidArg()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("WebView2 adapter is Windows-only");
+        }
+
+        var adapter = new TestableAdapter(new ThrowingFakeController());
+        
+        adapter.Focus();
+    }
+
+    private sealed class TestableAdapter(ICoreWebView2Controller controller)
+        : WebView2BaseAdapter(controller)
+    {
+        public override IntPtr Handle => IntPtr.Zero;
+        public override string? HandleDescriptor => null;
+    }
+
+    private sealed class ThrowingFakeController : ICoreWebView2Controller
+    {
+        void ICoreWebView2Controller.MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON reason)
+        {
+            // Marshal.GetExceptionForHR produces the exact ArgumentException with HResult
+            // E_INVALIDARG that the source-generated COM interop layer throws at runtime.
+            throw (ArgumentException)Marshal.GetExceptionForHR(unchecked((int)0x80070057))!;
+        }
+
+        void ICoreWebView2Controller.Close() { }
+
+        int ICoreWebView2Controller.GetIsVisible() => throw new NotImplementedException();
+        void ICoreWebView2Controller.SetIsVisible(int value) => throw new NotImplementedException();
+        tagRECT ICoreWebView2Controller.GetBounds() => throw new NotImplementedException();
+        void ICoreWebView2Controller.SetBounds(tagRECT value) => throw new NotImplementedException();
+        double ICoreWebView2Controller.GetZoomFactor() => throw new NotImplementedException();
+        void ICoreWebView2Controller.SetZoomFactor(double value) => throw new NotImplementedException();
+        void ICoreWebView2Controller.add_ZoomFactorChanged(IntPtr eventHandler, out EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.remove_ZoomFactorChanged(EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.SetBoundsAndZoomFactor(tagRECT bounds, double zoomFactor) => throw new NotImplementedException();
+        void ICoreWebView2Controller.add_MoveFocusRequested(ICoreWebView2MoveFocusRequestedEventHandler eventHandler, out EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.remove_MoveFocusRequested(EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.add_GotFocus(ICoreWebView2FocusChangedEventHandler eventHandler, out EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.remove_GotFocus(EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.add_LostFocus(ICoreWebView2FocusChangedEventHandler eventHandler, out EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.remove_LostFocus(EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.add_AcceleratorKeyPressed(IntPtr eventHandler, out EventRegistrationToken token) => throw new NotImplementedException();
+        void ICoreWebView2Controller.remove_AcceleratorKeyPressed(EventRegistrationToken token) => throw new NotImplementedException();
+        IntPtr ICoreWebView2Controller.GetParentWindow() => throw new NotImplementedException();
+        void ICoreWebView2Controller.SetParentWindow(IntPtr value) => throw new NotImplementedException();
+        void ICoreWebView2Controller.NotifyParentWindowPositionChanged() => throw new NotImplementedException();
+        ICoreWebView2 ICoreWebView2Controller.GetCoreWebView2() => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Problem

`NativeWebView` crashes with `System.ArgumentException` ("Value does not fall
within the expected range") on Windows whenever the host window is activated
while the WebView2 controller is in a transient state. This includes first
launch and rapid alt-tab. 

Root cause: `WebView2BaseAdapter.Focus()` called `ICoreWebView2Controller.MoveFocus()`
unconditionally. Win32 `WM_ACTIVATE` fires synchronously before the async
controller creation completes, so `MoveFocus` returns `E_INVALIDARG` (0x80070057),
which `Marshal.ThrowExceptionForHR` converts to `ArgumentException`.

This is the same class of bug Microsoft fixed in `Microsoft.Web.WebView2.Wpf`
across multiple SDK releases via a null guard and exception suppression around
`MoveFocus`.

## How I reproduced the crash

I ran the Desktop samples, moved the scroll bar thumb down and minimized the window. Then clicked task bar icon to restore window. This caused the crash for me. In my own app I could reproduce the the crash by minimizing and restoring many times in succession by repeatedly clicking the task bar and eventually it would crash.

I'm on the lastest (to my knowledge) version of WebView2: 147.0.3912.98

## Fix

Added a private `SafeCallController(Action)` helper in `WebView2BaseAdapter`
that mirrors Microsoft's `SafeAccessController` pattern:

- Guards on `Disposed || controller == null`
- Catches `ArgumentException` with `HResult == E_INVALIDARG` — the observed
  crash path via `Marshal.ThrowExceptionForHR`
- Catches `COMException` with `E_INVALIDARG` or `ERROR_INVALID_STATE` — the
  same rejection surfaced via alternate interop paths during teardown

`Focus()` now delegates through `SafeCallController`. All other controller
call sites are unchanged — `SafeCallController` is intentionally narrow.

HRESULT values are named constants in a private nested `HResult` class.

## Test

`WebView2BaseAdapterTests.FocusShouldNotThrowWhenControllerThrowsEInvalidArg`
uses a fake `ICoreWebView2Controller` that throws the exact `ArgumentException`
the COM layer produces at runtime (`Marshal.GetExceptionForHR(E_INVALIDARG)`).
The test fails against the unfixed code and passes after the fix. Skipped on
non-Windows.

I also verified manually that I could no longer reproduce the crash.

Closes #27