### PR TITLE
Add DeleteCookie(System.Net.Cookie cookie)

### DIFF
--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
@@ -67,7 +67,7 @@ public partial class MainView : UserControl
             foreach (var c in cookies)
             {
                 LogList.Text += "\r\nCookie retrieved " + c;
-                manager.DeleteCookie(c.Name, c.Domain, c.Path);
+                manager.DeleteCookie(c);
             }
 
             cookies = await manager.GetCookiesAsync();

--- a/src/Avalonia.Controls.WebView.Core/Android/AndroidWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Android/AndroidWebViewAdapter.cs
@@ -266,6 +266,11 @@ internal class AndroidWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapter
         }
     }
 
+    public void DeleteCookie(System.Net.Cookie cookie)
+    {
+        DeleteCookie(cookie.Name, cookie.Domain, cookie.Path);
+    }
+
     public Task<IReadOnlyList<Cookie>> GetCookiesAsync()
     {
         var cookies = new List<Cookie>();

--- a/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
@@ -398,6 +398,7 @@ internal interface IWebViewAdapterWithCookieManager : IWebViewAdapter
 {
     void AddOrUpdateCookie(System.Net.Cookie cookie);
     void DeleteCookie(string name, string domain, string path);
+    void DeleteCookie(System.Net.Cookie cookie);
     Task<IReadOnlyList<System.Net.Cookie>> GetCookiesAsync();
 }
 

--- a/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
@@ -844,9 +844,14 @@ internal sealed unsafe class WpeWebViewAdapter
 
     public void DeleteCookie(string name, string domain, string path)
     {
+        DeleteCookie(new Cookie(name, "", path, domain));
+    }
+
+    public void DeleteCookie(Cookie cookie)
+    {
         if (_cookieManager == IntPtr.Zero || _disposed) return;
 
-        var soupCookie = WpeInterop.soup_cookie_new(name, "", domain, path, 0);
+        var soupCookie = WpeInterop.soup_cookie_new(cookie.Name, cookie.Value, cookie.Domain, cookie.Path, 0);
         if (soupCookie != IntPtr.Zero)
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
@@ -431,8 +431,13 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
 
     public void DeleteCookie(string name, string domain, string path)
     {
+        DeleteCookie(new Cookie(name, ".", path, domain));
+    }
+
+    public void DeleteCookie(Cookie cookie)
+    {
         using var cookieStore = _config.WebsiteDataStore.HttpCookieStore;
-        cookieStore.DeleteCookie(new Cookie(name, ".", path, domain));
+        cookieStore.DeleteCookie(cookie);
     }
 
     public async Task<IReadOnlyList<Cookie>> GetCookiesAsync()

--- a/src/Avalonia.Controls.WebView.Core/NativeWebViewCookieManager.cs
+++ b/src/Avalonia.Controls.WebView.Core/NativeWebViewCookieManager.cs
@@ -13,6 +13,8 @@ public sealed class NativeWebViewCookieManager
     }
 
     public void AddOrUpdateCookie(System.Net.Cookie cookie) => _webView.AddOrUpdateCookie(cookie);
+    [System.Obsolete("Use DeleteCookie(System.Net.Cookie cookie) instead")]
     public void DeleteCookie(string name, string domain, string path) => _webView.DeleteCookie(name, domain, path);
+    public void DeleteCookie(System.Net.Cookie cookie) => _webView.DeleteCookie(cookie);
     public Task<IReadOnlyList<System.Net.Cookie>> GetCookiesAsync() => _webView.GetCookiesAsync();
 }

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
@@ -385,6 +385,11 @@ internal abstract partial class WebView2BaseAdapter(ICoreWebView2Controller cont
         }
     }
 
+    public void DeleteCookie(Cookie cookie)
+    {
+        DeleteCookie(cookie.Name, cookie.Domain, cookie.Path);
+    }
+
     public async Task<IReadOnlyList<Cookie>> GetCookiesAsync()
     {
         if (TryGetWebView2() is ICoreWebView2_2 webView2)


### PR DESCRIPTION
Due to a [limitation in libsoup](https://gitlab.gnome.org/GNOME/libsoup/-/issues/520), the current interface cannot delete cookies based on a specified name, domain, and path, without cookie value.