### PR TITLE
Allow WebView1 to be used over WebView2 if desired.

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Platform/WindowsWebView2EnvironmentRequestedEventArgs.cs
+++ b/src/Avalonia.Controls.WebView.Core/Platform/WindowsWebView2EnvironmentRequestedEventArgs.cs
@@ -14,7 +14,7 @@ public sealed class WindowsWebView2EnvironmentRequestedEventArgs : WebViewEnviro
     /// <summary>
     /// Gets or sets a value indicating whether to prefer WebView1 instead of WebView2.
     /// </summary>
-    internal bool PreferWebView1Instead { get; set; }
+    public bool PreferWebView1Instead { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable offscreen composition mode.


### PR DESCRIPTION
Reverts a "change" that makes `PreferWebView1Instead` internal instead of public.

> I am not sure if this was an intentional change as seen here:
> - https://github.com/AvaloniaUI/Avalonia.Controls.WebView/blob/b1054e2ff9379d1721cefbcaeee8fd13fea107d4/src/Avalonia.Controls.WebView.Core/Platform/WindowsWebView2EnvironmentRequestedEventArgs.cs
>
> Having the option to swap between WebView2 & WebView1 on Windows would be useful.