### PR TITLE
Generate CycloneDX SBOMs for the shipped NuGet packages

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -27,6 +27,7 @@
         "Compile",
         "CopyPackagesToNuGetCache",
         "CreateNugetPackages",
+        "CreateSbom",
         "IlMerge",
         "OutputParameters",
         "RunTests"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -18,6 +18,9 @@ class Build : NukeBuild
         Execute<Build>(x => x.CreateNugetPackages);
 
     [NuGetPackage("dotnet-ilrepack", "ILRepackTool.dll", Framework = "net8.0")] readonly Tool IlRepackTool = null!;
+    // net8.0 to match this build project's own TFM, so local packaging (which triggers
+    // CreateSbom) doesn't require a newer runtime than the build itself.
+    [NuGetPackage("CycloneDX", "CycloneDX.dll", Framework = "net8.0")] readonly Tool CycloneDx = null!;
 
     [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
     readonly Configuration Configuration = Configuration.Release;
@@ -105,8 +108,41 @@ class Build : NukeBuild
             }
         });
 
+    // Runs whenever packages are produced (TriggeredBy), so the default CI target
+    // 'CreateNugetPackages' generates and embeds SBOMs without workflow changes.
+    // Avalonia.Controls.WebView.Core is IL-merged into both shipped packages (see IlMerge)
+    // rather than shipped on its own, so each package's SBOM is generated from the package's
+    // own project plus Core, making Core's dependencies part of both packages' SBOMs.
+    Target CreateSbom => _ => _
+        .DependsOn(CreateNugetPackages)
+        .TriggeredBy(CreateNugetPackages)
+        .Executes(() =>
+        {
+            var sbomRoot = RootDirectory / "artifacts" / "sbom";
+            sbomRoot.CreateOrCleanDirectory();
+
+            var version = GetVersion();
+            foreach (var packageId in new[] { "Avalonia.Controls.WebView", "Avalonia.Xpf.Controls.WebView" })
+            {
+                var packagePath = Output / $"{packageId}.{version}.nupkg";
+                if (!packagePath.FileExists())
+                    throw new InvalidOperationException($"SBOM: expected package {packagePath} was not built.");
+
+                SbomGenerator.GenerateForPackage(
+                    CycloneDx,
+                    RootDirectory,
+                    packagePath,
+                    sbomRoot,
+                    version,
+                    packageId,
+                    [packageId, "Avalonia.Controls.WebView.Core"]);
+            }
+        });
+
     Target CopyPackagesToNuGetCache => _ => _
         .DependsOn(CreateNugetPackages)
+        // CreateSbom embeds the SBOM into each .nupkg, so copy to the cache only afterwards.
+        .After(CreateSbom)
         .Executes(() => NugetCache.InstallLibraryToNuGetCache(
             Output.GlobFiles("*.nupkg"),
             RootDirectory,

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Nuke.Common" Version="9.0.4"/>
     <PackageDownload Include="dotnet-ilrepack" Version="[1.0.0]" />
     <PackageDownload Include="Microsoft.Android.Ref.34" Version="[34.0.148]" />
+    <PackageDownload Include="CycloneDX" Version="[6.2.0]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds a `CreateSbom` nuke target that produces a **CycloneDX SBOM** for both shipped packages (`Avalonia.Controls.WebView`, `Avalonia.Xpf.Controls.WebView`), as EU Cyber Resilience Act technical-documentation evidence. Uses the shared generator merged in AvaloniaUI/build-common#4; see AvaloniaUI/Avalonia.Controls.TreeDataGrid-Accelerate#169 for the pilot.

- `CreateSbom` is `.TriggeredBy(CreateNugetPackages)`, so the default CI target used by `library-cicd.yml` generates and embeds SBOMs with no workflow changes; the shared workflow uploads `artifacts/sbom` as an `sbom` artifact automatically.
- `Avalonia.Controls.WebView.Core` is IL-merged into both shipped packages rather than shipped standalone, so each package'"'"'s SBOM is generated from the package project **plus Core** via `GenerateForPackage` — Core'"'"'s dependencies (SkiaSharp, HarfBuzz, AndroidX, ...) appear in both packages'"'"' SBOMs.
- Each SBOM is enriched from the shipped nuspec and embedded into the `.nupkg` at `_manifest/cyclonedx/bom.cdx.json`. The CycloneDX tool is resolved from its net8.0 build, matching this build project'"'"'s TFM.

## Test plan

- [x] Verified locally against real packed output of both packages: the XPF SBOM contains its own WpfAbstractions dependency plus all of Core'"'"'s dependencies unioned in
- [ ] CI run on this PR validates the real IL-merged path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qDKmcNFxV3Xk5PjTGKrK6