### PR TITLE
macOS: only report Undo and Redo handled when the undo manager can act

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/AppleView.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/AppleView.cs
@@ -22,6 +22,8 @@ internal unsafe class AppleView : NSManagedObjectBase
     private static readonly IntPtr s_cut = Libobjc.sel_getUid("cut:");
     private static readonly IntPtr s_selectAll = Libobjc.sel_getUid("selectAll:");
     private static readonly IntPtr s_undoManager = Libobjc.sel_getUid("undoManager");
+    private static readonly IntPtr s_undoManagerCanRedo = Libobjc.sel_getUid("canRedo");
+    private static readonly IntPtr s_undoManagerCanUndo = Libobjc.sel_getUid("canUndo");
     private static readonly IntPtr s_undoManagerRedo = Libobjc.sel_getUid("redo");
     private static readonly IntPtr s_undoManagerUndo = Libobjc.sel_getUid("undo");
 
@@ -120,6 +122,9 @@ internal unsafe class AppleView : NSManagedObjectBase
     {
         var undoManagerPtr = Libobjc.intptr_objc_msgSend(Handle, s_undoManager);
         if (undoManagerPtr == IntPtr.Zero) return false;
+        // Report unhandled when there is nothing to undo, so the key equivalent can continue to other
+        // consumers (an NSView practically always has an undo manager, but not an undo stack).
+        if (Libobjc.int_objc_msgSend(undoManagerPtr, s_undoManagerCanUndo) == 0) return false;
         Libobjc.void_objc_msgSend(undoManagerPtr, s_undoManagerUndo);
         return true;
     }
@@ -127,6 +132,7 @@ internal unsafe class AppleView : NSManagedObjectBase
     {
         var undoManagerPtr = Libobjc.intptr_objc_msgSend(Handle, s_undoManager);
         if (undoManagerPtr == IntPtr.Zero) return false;
+        if (Libobjc.int_objc_msgSend(undoManagerPtr, s_undoManagerCanRedo) == 0) return false;
         Libobjc.void_objc_msgSend(undoManagerPtr, s_undoManagerRedo);
         return true;
     }


### PR DESCRIPTION
## What does the pull request do?

Makes the macOS adapter's `Undo`/`Redo` key-equivalent handling report unhandled when the undo manager
cannot act, so Command+Z / Shift+Command+Z are no longer consumed when there is nothing to undo. This
lets the key reach the page (and the host framework's input pipeline), enabling applications to
implement their own undo shortcuts over page content — for example an application-level undo bound in a
Blazor/JS layer hosted inside `NativeWebView`.

## What is the current behavior?

`AppleView.Undo()`/`Redo()` return true whenever the view exposes an undo manager — which an `NSView`
practically always does — so `performKeyEquivalent:` reports Command+Z / Shift+Command+Z handled even
when the undo manager has an empty stack. Outside an editable element the key is swallowed entirely: the
engine's undo manager no-ops, the page never receives the key down, and the event is not forwarded to
the host framework either.

## What is the updated/expected behavior with this PR?

`Undo`/`Redo` consult `canUndo`/`canRedo` before invoking and report unhandled when the manager cannot
act, so the key equivalent continues to the remaining consumers. Text-editing undo inside editable
elements is unchanged — there the manager can act, and the behavior is identical to today.

To test: host a page in `NativeWebView` on macOS with a `keydown` listener for Command+Z outside any
editable element. Before this change the listener never fires; after it, the key reaches the page.
Typing in a text field and pressing Command+Z still performs the native text undo.

## How was the solution implemented (if it's not obvious)?

Two additional selectors (`canUndo`, `canRedo`) on the existing undo-manager interop path; no API
surface changes.

## Breaking changes

None.

## Fixed issues

None filed; found while implementing an application-level undo shortcut over hosted page content.
