### PR TITLE
macOS: raise WebContentProcessTerminated when the web content process dies

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
@@ -385,6 +385,16 @@ internal interface IWebViewAdapterWithInputRedirect : IWebViewAdapter
     event Action<RoutedEventArgs> Input;
 }
 
+internal interface IWebViewAdapterWithProcessTermination : IWebViewAdapter
+{
+    /// <summary>
+    ///     WebContentProcessTerminated dispatches after the web content process backing the webview terminates,
+    ///     for example after a crash or after the operating system reclaims its memory. The native control stays
+    ///     alive but renders nothing until the page is reloaded.
+    /// </summary>
+    event EventHandler? WebContentProcessTerminated;
+}
+
 internal interface IWebViewAdapterWithCommands
 {
     void Copy();

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKNavigationDelegate.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKNavigationDelegate.cs
@@ -14,6 +14,8 @@ internal unsafe class WKNavigationDelegate : NSManagedObjectBase
         s_willPresentNotification = &OnDidFinishNavigation;
     private static readonly delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, void>
         s_decidePolicyForNavigationAction = &OnDecidePolicyForNavigationAction;
+    private static readonly delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, void>
+        s_webContentProcessDidTerminate = &OnWebContentProcessDidTerminate;
 
     static WKNavigationDelegate()
     {
@@ -31,6 +33,10 @@ internal unsafe class WKNavigationDelegate : NSManagedObjectBase
         result = Libobjc.class_addMethod(delegateClass, didReceiveNotificationResponse, s_decidePolicyForNavigationAction, "v@:@@@");
         Debug.Assert(result == 1);
 
+        var webContentProcessDidTerminateSel = Libobjc.sel_getUid("webViewWebContentProcessDidTerminate:");
+        result = Libobjc.class_addMethod(delegateClass, webContentProcessDidTerminateSel, s_webContentProcessDidTerminate, "v@:@");
+        Debug.Assert(result == 1);
+
         result = RegisterManagedMembers(delegateClass) ? 1 : 0;
         Debug.Assert(result == 1);
 
@@ -45,12 +51,20 @@ internal unsafe class WKNavigationDelegate : NSManagedObjectBase
 
     public event EventHandler? DidFinishNavigation;
     public event EventHandler<DecidePolicyNavigationEventArgs>? DecidePolicyNavigation;
+    public event EventHandler? WebContentProcessDidTerminate;
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void OnDidFinishNavigation(IntPtr self, IntPtr sel, IntPtr webView, IntPtr navigation)
     {
         var managed = ReadManagedSelf<WKNavigationDelegate>(self);
         managed?.DidFinishNavigation?.Invoke(managed, EventArgs.Empty);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnWebContentProcessDidTerminate(IntPtr self, IntPtr sel, IntPtr webView)
+    {
+        var managed = ReadManagedSelf<WKNavigationDelegate>(self);
+        managed?.WebContentProcessDidTerminate?.Invoke(managed, EventArgs.Empty);
     }
 
     private static readonly IntPtr s_actionRequest = Libobjc.sel_getUid("request");

--- a/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
@@ -18,7 +18,8 @@ namespace Avalonia.Controls.Macios;
 [SupportedOSPlatform("macos")]
 [SupportedOSPlatform("ios")]
 internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterWithInputRedirect,
-    IWebViewAdapterWithCookieManager, IWebViewAdapterWithCommands, IWebViewWithPrint, IAppleWKWebViewPlatformHandle
+    IWebViewAdapterWithCookieManager, IWebViewAdapterWithCommands, IWebViewAdapterWithProcessTermination,
+    IWebViewWithPrint, IAppleWKWebViewPlatformHandle
 {
     private const string DefaultPostAvWebViewMessageName = "postAvWebViewMessage";
 
@@ -73,6 +74,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
         _navDelegate = new WKNavigationDelegate();
         _navDelegate.DidFinishNavigation += OnDelegateOnDidFinishNavigation;
         _navDelegate.DecidePolicyNavigation += OnDelegateOnDecidePolicyNavigation;
+        _navDelegate.WebContentProcessDidTerminate += OnDelegateOnWebContentProcessDidTerminate;
 
         _webView = new WKWebView(_config) { NavigationDelegate = _navDelegate };
         _webView.Opaque = false;
@@ -157,6 +159,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
     public event EventHandler<WebResourceRequestedEventArgs>? WebResourceRequested;
     public event EventHandler? GotFocus;
     public event EventHandler<IWebViewAdapterWithFocus.LostFocusDirection>? LostFocus;
+    public event EventHandler? WebContentProcessTerminated;
     public event Action<RoutedEventArgs>? Input;
     public bool GoBack() => _webView.GoBack() != default;
     public bool GoForward() => _webView.GoForward() != default;
@@ -203,6 +206,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
         _scriptHandler.DidReceiveScriptMessage -= OnScriptHandlerOnDidReceiveScriptMessage;
         _navDelegate.DidFinishNavigation -= OnDelegateOnDidFinishNavigation;
         _navDelegate.DecidePolicyNavigation -= OnDelegateOnDecidePolicyNavigation;
+        _navDelegate.WebContentProcessDidTerminate -= OnDelegateOnWebContentProcessDidTerminate;
         _webView.PerformKeyEquivalent -= WebViewOnPerformKeyEquivalent;
         _webView.BecomeFirstResponder -= OnWebViewOnBecomeFirstResponder;
         _webView.ResignFirstResponder -= OnWebViewOnResignFirstResponder;
@@ -295,6 +299,11 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
 
         using var url = _webView.Url;
         NavigationCompleted?.Invoke(this, new WebViewNavigationCompletedEventArgs { Request = Uri.TryCreate(url!.AbsoluteString, UriKind.Absolute, out var uri) ? uri : null, IsSuccess = true });
+    }
+
+    private void OnDelegateOnWebContentProcessDidTerminate(object? sender, EventArgs args)
+    {
+        WebContentProcessTerminated?.Invoke(this, EventArgs.Empty);
     }
 
     private void OnWebViewOnResignFirstResponder(object? o, EventArgs eventArgs)

--- a/src/Avalonia.Controls.WebView/NativeWebDialog.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebDialog.cs
@@ -365,6 +365,17 @@ namespace Avalonia.Xpf.Controls
         public event EventHandler<Core.WebViewAdapterEventArgs>? AdapterDestroyed;
         public event EventHandler<Core.WebViewEnvironmentRequestedEventArgs>? EnvironmentRequested;
 
+        /// <summary>
+        ///     WebContentProcessTerminated dispatches after the web content process backing the webview terminates,
+        ///     for example after a crash or after the operating system reclaims its memory. The dialog stays open
+        ///     but renders nothing until the page is reloaded, so handle this event to <see cref="Navigate"/> again.
+        /// </summary>
+        /// <remarks>
+        ///     Raised by WebKit-based adapters (WKWebView on macOS and iOS). Other platforms do not raise this
+        ///     event yet.
+        /// </remarks>
+        public event EventHandler? WebContentProcessTerminated;
+
         /// <inheritdoc/>
         public Core.NativeWebViewCommandManager? TryGetCommandManager() => TryGetAdapter() switch
         {
@@ -465,6 +476,8 @@ namespace Avalonia.Xpf.Controls
             adapter.WebMessageReceived -= WebViewAdapterOnWebMessageReceived;
             adapter.WebResourceRequested -= WebViewAdapterOnWebResourceRequested;
             adapter.NewWindowRequested -= WebViewAdapterOnNewWindowRequested;
+            if (adapter is Core.IWebViewAdapterWithProcessTermination withProcessTermination)
+                withProcessTermination.WebContentProcessTerminated -= WebViewAdapterOnWebContentProcessTerminated;
             _dialogInitialized = false;
             AdapterDestroyed?.Invoke(this, e);
         }
@@ -492,6 +505,8 @@ namespace Avalonia.Xpf.Controls
                 adapter.WebResourceRequested += WebViewAdapterOnWebResourceRequested;
             if (_newWindowRequested is not null)
                 adapter.NewWindowRequested += WebViewAdapterOnNewWindowRequested;
+            if (adapter is Core.IWebViewAdapterWithProcessTermination withProcessTermination)
+                withProcessTermination.WebContentProcessTerminated += WebViewAdapterOnWebContentProcessTerminated;
             if (_initialSource is Uri url)
                 adapter.Source = url;
             else if (_initialSource is ValueTuple<string, Uri?> pair)
@@ -527,6 +542,11 @@ namespace Avalonia.Xpf.Controls
         private void WebViewAdapterOnNewWindowRequested(object? sender, Core.WebViewNewWindowRequestedEventArgs e)
         {
             _newWindowRequested?.Invoke(this, e);
+        }
+
+        private void WebViewAdapterOnWebContentProcessTerminated(object? sender, EventArgs e)
+        {
+            WebContentProcessTerminated?.Invoke(this, e);
         }
     }
 }

--- a/src/Avalonia.Controls.WebView/NativeWebView.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebView.cs
@@ -247,6 +247,18 @@ namespace Avalonia.Xpf.Controls
         /// <inheritdoc/>
         public event EventHandler<Core.WebViewAdapterEventArgs>? AdapterDestroyed;
 
+        /// <summary>
+        ///     WebContentProcessTerminated dispatches after the web content process backing the webview terminates,
+        ///     for example after a crash or after the operating system reclaims its memory. The native control stays
+        ///     alive but renders nothing until the page is reloaded, so handle this event to
+        ///     <see cref="Refresh"/> or <see cref="Navigate"/> again.
+        /// </summary>
+        /// <remarks>
+        ///     Raised by WebKit-based adapters (WKWebView on macOS and iOS). Other platforms do not raise this
+        ///     event yet.
+        /// </remarks>
+        public event EventHandler? WebContentProcessTerminated;
+
         /// <inheritdoc/>
         public Uri Source
         {
@@ -428,6 +440,12 @@ namespace Avalonia.Xpf.Controls
             _newWindowRequested?.Invoke(this, e);
         }
 
+        private void WebViewAdapterOnWebContentProcessTerminated(object? sender, EventArgs e)
+        {
+            Core.WebViewDispatcher.VerifyAccess();
+            WebContentProcessTerminated?.Invoke(this, e);
+        }
+
 #if AVALONIA
         protected override async void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
@@ -563,6 +581,10 @@ namespace Avalonia.Xpf.Controls
             {
                 withInput.Input -= WithInputOnInput;
             }
+            if (adapter is Core.IWebViewAdapterWithProcessTermination withProcessTermination)
+            {
+                withProcessTermination.WebContentProcessTerminated -= WebViewAdapterOnWebContentProcessTerminated;
+            }
 
             AdapterDestroyed?.Invoke(this, new Core.WebViewAdapterEventArgs(adapter));
         }
@@ -593,6 +615,11 @@ namespace Avalonia.Xpf.Controls
             if (adapter is Core.IWebViewAdapterWithInputRedirect withInput)
             {
                 withInput.Input += WithInputOnInput;
+            }
+
+            if (adapter is Core.IWebViewAdapterWithProcessTermination withProcessTermination)
+            {
+                withProcessTermination.WebContentProcessTerminated += WebViewAdapterOnWebContentProcessTerminated;
             }
 
             if (_initialSource is Uri url)


### PR DESCRIPTION
## What does the pull request do?

Adds a `WebContentProcessTerminated` event to `NativeWebView` and `NativeWebDialog`, raised on macOS and
iOS when the WKWebView's web content process terminates — after a renderer crash or after the operating
system reclaims its memory. This gives embedders the signal they need to recover (reload or re-navigate)
instead of leaving the user with a permanently blank view.

## What is the current behavior?

When the web content process dies, WKWebView keeps the native view alive but renders nothing, and WebKit
performs no recovery on its own. The only signal is the `WKNavigationDelegate`
`webViewWebContentProcessDidTerminate:` callback, which the managed delegate does not implement — so an
application hosting content in `NativeWebView` has no way to observe the loss. The practical workaround
is an out-of-band liveness probe: we ship a production application on `NativeWebView` and currently run
a page-side heartbeat purely to detect this condition.

## What is the updated/expected behavior with this PR?

The managed `WKNavigationDelegate` implements `webViewWebContentProcessDidTerminate:` and the macOS/iOS
adapter surfaces it through a new internal `IWebViewAdapterWithProcessTermination` capability, exposed as
a public `WebContentProcessTerminated` event on `NativeWebView` and `NativeWebDialog`. A typical handler
calls `Refresh()` or navigates again. Platforms whose adapters do not implement the capability are
unaffected; the event is documented as WebKit-only for now.

To test on macOS: host any page in `NativeWebView`, subscribe to the event, and kill the web content
process (`kill -9` the "WebKit WebContent" process belonging to the application, or trigger
`window.internals`-free equivalents such as loading a page that exhausts renderer memory). Before this
change the view silently blanks; after it, the event fires and the handler can reload.

## How was the solution implemented (if it's not obvious)?

The delegate method is registered on the existing `ManagedWKNavigationDelegate` class alongside the
current navigation callbacks (`v@:@` signature, one unmanaged callback). The adapter forwards it through
the same capability-interface pattern used by `IWebViewAdapterWithFocus` and friends: the controls
subscribe at adapter creation and unsubscribe at destruction, and the event never fires on platforms
without the capability. WebView2's `ProcessFailed` could back the same event on Windows in a follow-up.

## Breaking changes

None. New public event; no existing behavior changes.

## Fixed issues

None filed; found while hosting a long-running application in `NativeWebView`, where a terminated
content process previously required a heartbeat probe to detect.
