### PR TITLE
GTK: Offscreen pixel buffer fixes and several marshalling issues

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Gtk/GdkEvent.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GdkEvent.cs
@@ -94,7 +94,7 @@ internal struct GdkEventScroll
     public Double x_root, y_root;
     public Double delta_x;
     public Double delta_y;
-    public bool is_stop;//public guint is_stop : 1;
+    public UInt32 is_stop;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -110,7 +110,7 @@ internal struct GdkEventCrossing
     public Double x_root, y_root;
     public Int32 mode;
     public Int32 detail;
-    public bool focus;
+    public Int32 focus;
     public UInt32 state;
 }
 
@@ -154,5 +154,5 @@ internal unsafe struct GdkEventKey
     public Byte *_string;
     public UInt16 hardware_keycode;
     public Byte group;
-    public bool is_modifier;//public guint is_modifier : 1;
+    public UInt32 is_modifier;
 }

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkInterop.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkInterop.cs
@@ -85,7 +85,7 @@ internal static unsafe partial class GtkInterop
     [DllImport(LibWebKit)]
     internal static extern IntPtr webkit_web_view_get_uri(IntPtr webView);
 
-    [DllImport(LibGio)]
+    [DllImport(LibGLib)]
     internal static extern void g_free(IntPtr ptr);
 
     [DllImport(LibGio)]
@@ -95,7 +95,7 @@ internal static unsafe partial class GtkInterop
     internal static extern IntPtr g_main_context_default();
 
     [LibraryImport(LibGLib)]
-    [return: MarshalAs(UnmanagedType.I1)]
+    [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool g_main_context_is_owner(IntPtr context);
 
     [DllImport(LibWebKit)]
@@ -105,7 +105,7 @@ internal static unsafe partial class GtkInterop
     internal static extern void webkit_user_content_manager_add_script(IntPtr manager, IntPtr userScript);
 
     [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
-    [return: MarshalAs(UnmanagedType.I1)]
+    [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool webkit_user_content_manager_register_script_message_handler(IntPtr manager, string messageHandler);
 
     [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
@@ -174,10 +174,10 @@ internal static unsafe partial class GtkInterop
     [DllImport(LibWebKit)]
     public static extern void webkit_print_operation_set_page_setup(IntPtr operation, IntPtr pageSetup);
 
-    [DllImport(LibWebKit)]
+    [DllImport(LibGtk)]
     public static extern IntPtr gtk_print_settings_new();
 
-    [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    [LibraryImport(LibGtk, StringMarshalling = StringMarshalling.Utf8)]
     internal static partial void gtk_print_settings_set(IntPtr settings, string key, string value);
 
     [DllImport(LibGtk)]
@@ -218,8 +218,8 @@ internal static unsafe partial class GtkInterop
     [DllImport(LibGtk)]
     internal static extern void gtk_widget_destroy(IntPtr widget);
 
-    [DllImport(LibGObject)]
-    internal static extern ulong g_error_free(GError* error);
+    [DllImport(LibGLib)]
+    internal static extern void g_error_free(GError* error);
 
     [DllImport(LibGObject)]
     internal static extern IntPtr g_object_ref(IntPtr handle);
@@ -230,8 +230,8 @@ internal static unsafe partial class GtkInterop
     [DllImport (LibGObject)]
     internal static extern void g_object_unref(IntPtr handle);
 
-    [LibraryImport(LibGObject, StringMarshalling = StringMarshalling.Utf8)]
-    internal static partial void g_variant_get(IntPtr variant, string formatString, out string? result);
+    [LibraryImport(LibGLib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void g_variant_get(IntPtr variant, string formatString, out IntPtr result);
 
     [DllImport(LibGtk)]
     internal static extern IntPtr gtk_window_new(int type);
@@ -312,7 +312,7 @@ internal static unsafe partial class GtkInterop
     internal static extern IntPtr gdk_keymap_get_for_display(IntPtr display);
 
     [LibraryImport (LibGdk)]
-    [return: MarshalAs(UnmanagedType.I1)]
+    [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool gdk_keymap_translate_keyboard_state(IntPtr keymap, uint hardware_keycode, GdkModifierType state, int group, out uint keyval, out int effective_group, out int level, out int consumed_modifiers);
 
     [DllImport(LibGdk)]
@@ -351,10 +351,10 @@ internal static unsafe partial class GtkInterop
     [DllImport(LibGdk)]
     public static extern IntPtr gdk_event_new(GdkEventType type);
 
-    [DllImport(LibGdk)]
+    [DllImport(LibGtk)]
     public static extern bool gtk_widget_event(IntPtr widget, IntPtr gdkEvent);
 
-    [DllImport(LibGdk)]
+    [DllImport(LibGtk)]
     public static extern void gtk_main_do_event(IntPtr gdkEvent);
 
     [DllImport(LibGdk)]
@@ -453,7 +453,7 @@ internal static unsafe partial class GtkInterop
     public static extern void soup_message_headers_foreach(
         IntPtr headers,
         delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, void> func,
-        GCHandle user_data);
+        IntPtr user_data);
 
     // Don't return string for SOUP headers, we don't want to auto-release them (as it's done by LibraryImport)
     [LibraryImport(LibSoup, StringMarshalling = StringMarshalling.Utf8)]
@@ -556,9 +556,11 @@ internal static unsafe partial class GtkInterop
         public int width, height;
     }
 
+    [Flags]
     public enum GConnectFlags : int
     {
-        AFTER,
-        SWAPPED
+        NONE = 0,
+        AFTER = 1 << 0,
+        SWAPPED = 1 << 1
     }
 }

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkInterop.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkInterop.cs
@@ -455,10 +455,11 @@ internal static unsafe partial class GtkInterop
         delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, void> func,
         GCHandle user_data);
 
+    // Don't return string for SOUP headers, we don't want to auto-release them (as it's done by LibraryImport)
     [LibraryImport(LibSoup, StringMarshalling = StringMarshalling.Utf8)]
-    public static partial string? soup_message_headers_get_list(IntPtr headers, string name);
+    public static partial IntPtr soup_message_headers_get_list(IntPtr headers, string name);
     [LibraryImport(LibSoup, StringMarshalling = StringMarshalling.Utf8)]
-    public static partial string? soup_message_headers_get_one(IntPtr headers, string name);
+    public static partial IntPtr soup_message_headers_get_one(IntPtr headers, string name);
     [LibraryImport(LibSoup, StringMarshalling = StringMarshalling.Utf8)]
     public static partial void soup_message_headers_replace(IntPtr headers, string name, string value);
     [LibraryImport(LibSoup, StringMarshalling = StringMarshalling.Utf8)]

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenAvaloniaWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenAvaloniaWebViewAdapter.cs
@@ -31,15 +31,19 @@ internal sealed class GtkOffscreenAvaloniaWebViewAdapter : GtkOffscreenWebViewAd
 
     public Control? Parent { get; private set; }
 
-    public static async Task<WebViewAdapter.OffscreenWebViewAdapterBuilder> CreateBuilder(
+    public static Task<WebViewAdapter.OffscreenWebViewAdapterBuilder> CreateBuilder(
         GtkWebViewEnvironmentRequestedEventArgs environmentArgs)
     {
-        var adapter = await RunOnGlibThreadAsync(() => new GtkOffscreenAvaloniaWebViewAdapter(environmentArgs));
-        return (parent) =>
+        // A fresh adapter per attachment: the host disposes the previous one when the control is
+        // detached, so handing out a cached instance leaves a dead web view after a re-attach.
+        WebViewAdapter.OffscreenWebViewAdapterBuilder builder = async parent =>
         {
+            var adapter = await RunOnGlibThreadAsync(() => new GtkOffscreenAvaloniaWebViewAdapter(environmentArgs));
             adapter.Parent = parent;
-            return Task.FromResult<IWebViewAdapterWithOffscreenBuffer>(adapter);
+            return adapter;
         };
+
+        return Task.FromResult(builder);
     }
 
     protected override void DisposeSafe(bool disposing)

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenWebViewAdapter.cs
@@ -325,8 +325,10 @@ internal abstract unsafe class GtkOffscreenWebViewAdapter : GtkWebViewAdapter,
 
         if (window != IntPtr.Zero)
         {
-            g_object_unref(window);
+            // Destroy before releasing our reference: unreffing first can drop the last reference,
+            // and gtk_widget_destroy would then run against freed memory.
             gtk_widget_destroy(window);
+            g_object_unref(window);
         }
     }
 

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenWebViewAdapter.cs
@@ -138,12 +138,12 @@ internal abstract unsafe class GtkOffscreenWebViewAdapter : GtkWebViewAdapter,
 
     public override void SizeChanged(PixelSize containerSize)
     {
-        if (_windowHandle == IntPtr.Zero)
-            return;
-
         _sizeRequest = containerSize;
         RunOnGlibThreadAsync(() =>
         {
+            if (_windowHandle == IntPtr.Zero)
+                return;
+
             if (_experimentalOffscreen)
                 gtk_window_set_default_size(_windowHandle, _sizeRequest.Width, _sizeRequest.Height);
             else

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkOffscreenWebViewAdapter.cs
@@ -38,7 +38,10 @@ internal abstract unsafe class GtkOffscreenWebViewAdapter : GtkWebViewAdapter,
     }
 
     public event Action? DrawRequested;
-    
+
+    public PixelFormat BufferPixelFormat => PixelFormats.Rgba8888;
+    public AlphaFormat BufferAlphaFormat => AlphaFormat.Unpremul;
+
     public Task UpdateWriteableBitmap(PixelSize _, FrameChainBase<WriteableBitmap, PixelSize>.IProducer producer)
     {
         if (_windowHandle == IntPtr.Zero)
@@ -65,11 +68,6 @@ internal abstract unsafe class GtkOffscreenWebViewAdapter : GtkWebViewAdapter,
                 int wHeight = gtk_widget_get_allocated_height(_windowHandle);
 
                 pixbuf = gdk_pixbuf_get_from_window(gdkWindow, 0, 0, wWidth, wHeight);
-                if (pixbuf != IntPtr.Zero && gdk_pixbuf_get_n_channels(pixbuf) == 3)
-                {
-                    var pixbufRgba = gdk_pixbuf_add_alpha(pixbuf, false, 0, 0, 0);
-                    pixbuf = pixbufRgba;
-                }
             }
 
             if (pixbuf == IntPtr.Zero)
@@ -79,34 +77,61 @@ internal abstract unsafe class GtkOffscreenWebViewAdapter : GtkWebViewAdapter,
 
             try
             {
+                // Windows without an alpha channel produce a three channel pixbuf.
+                if (gdk_pixbuf_get_n_channels(pixbuf) == 3)
+                {
+                    var pixbufRgba = gdk_pixbuf_add_alpha(pixbuf, false, 0, 0, 0);
+                    g_object_unref(pixbuf);
+                    pixbuf = pixbufRgba;
+
+                    if (pixbuf == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                }
+
                 var width = gdk_pixbuf_get_width(pixbuf);
                 var height = gdk_pixbuf_get_height(pixbuf);
                 var stride = gdk_pixbuf_get_rowstride(pixbuf);
                 var channels = gdk_pixbuf_get_n_channels(pixbuf);
                 var pixelsPtr = gdk_pixbuf_get_pixels(pixbuf);
 
+                if (width <= 0 || height <= 0 || channels != 4 || pixelsPtr == IntPtr.Zero)
+                {
+                    return;
+                }
+
                 var size = new PixelSize(width, height);
 
-                if (channels == 4)
+                using (producer.GetNextFrame(size, out var frame))
                 {
-                    using (producer.GetNextFrame(size, out var frame))
-                    {
-                        using var buf = frame.Lock();
-                        var bytesPerRow = Math.Min(stride, buf.RowBytes);
-                        var totalBytes = bytesPerRow * height;
+                    using var buf = frame.Lock();
+                    var dstStride = buf.RowBytes;
 
-                        Buffer.MemoryCopy(
-                            source: (void*)pixelsPtr,
-                            destination: (void*)buf.Address,
-                            destinationSizeInBytes: buf.RowBytes * height,
-                            sourceBytesToCopy: totalBytes
-                        );
+                    if (stride == dstStride)
+                    {
+                        Buffer.MemoryCopy((void*)pixelsPtr, (void*)buf.Address,
+                            (long)height * dstStride, (long)height * stride);
+                    }
+                    else
+                    {
+                        var copyBytes = Math.Min(stride, dstStride);
+                        for (var y = 0; y < height; y++)
+                        {
+                            Buffer.MemoryCopy(
+                                (byte*)pixelsPtr + (long)y * stride,
+                                (byte*)buf.Address + (long)y * dstStride,
+                                dstStride, copyBytes);
+                        }
                     }
                 }
             }
             finally
             {
-                g_object_unref(pixbuf);
+                if (pixbuf != IntPtr.Zero)
+                {
+                    g_object_unref(pixbuf);
+                }
             }
         });
     }

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
@@ -48,6 +48,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
         new((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, void>)&ResourceLoadStartedCallback);
 
     private readonly IntPtr _settings;
+    private IntPtr _webViewHandle;
     private GtkSignal? _loadChangedSignal;
     private GtkSignal? _decidePolicySignal;
     private GtkSignal? _focusInSignal;
@@ -107,7 +108,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             context = webkit_web_context_get_default();
         }
 
-        WebViewHandle = webkit_web_view_new_with_context(context);
+        _webViewHandle = webkit_web_view_new_with_context(context);
 
         var contentManager = webkit_web_view_get_user_content_manager(WebViewHandle);
         _scriptMessageReceivedSignal = new GtkSignal(contentManager, $"script-message-received::{PostAvWebViewMessageName}", s_scriptMessageReceivedCallback, this);
@@ -143,7 +144,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
         _resourceLoadStarted = new GtkSignal(WebViewHandle, "resource-load-started", s_resourceLoadStartedCallback, this);
     }
 
-    public IntPtr WebViewHandle { get; private set; }
+    public IntPtr WebViewHandle => _webViewHandle;
 
     IntPtr IPlatformHandle.Handle => WebViewHandle;
     string IPlatformHandle.HandleDescriptor => "WebKitWebView";
@@ -623,16 +624,21 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             Interlocked.Exchange(ref _resourceLoadStarted, null)?.Dispose();
         }
 
-        WebViewHandle = IntPtr.Zero;
+        var webView = Interlocked.Exchange(ref _webViewHandle, IntPtr.Zero);
+        if (webView != IntPtr.Zero)
+        {
+            gtk_widget_destroy(webView);
+            g_object_unref(webView);
+        }
     }
 
     public void Dispose()
     {
+        GC.SuppressFinalize(this);
         RunOnGlibThreadAsync(() =>
         {
             DisposeSafe(true);
         });
-        GC.SuppressFinalize(this);
     }
 
     ~GtkWebViewAdapter()

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
@@ -148,8 +148,8 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
     IntPtr IPlatformHandle.Handle => WebViewHandle;
     string IPlatformHandle.HandleDescriptor => "WebKitWebView";
 
-    public bool CanGoBack => RunOnGlibThread(() => webkit_web_view_can_go_back(WebViewHandle));
-    public bool CanGoForward => RunOnGlibThread(() => webkit_web_view_can_go_forward(WebViewHandle));
+    public bool CanGoBack => RunOnWebView(webkit_web_view_can_go_back);
+    public bool CanGoForward => RunOnWebView(webkit_web_view_can_go_forward);
 
     public string? UserAgent
     {
@@ -192,10 +192,10 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
     public event EventHandler? GotFocus;
     public event EventHandler<IWebViewAdapterWithFocus.LostFocusDirection>? LostFocus;
 
-    public void Focus() => RunOnGlibThreadAsync(() =>
+    public void Focus() => RunOnWebView(static handle =>
     {
-        gtk_widget_grab_focus(WebViewHandle);
-        return gtk_widget_has_focus(WebViewHandle);
+        gtk_widget_grab_focus(handle);
+        gtk_widget_has_focus(handle);
     });
 
     public void ResignFocus() { }
@@ -207,7 +207,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             return false;
         }
 
-        RunOnGlibThreadAsync(() => webkit_web_view_go_back(WebViewHandle));
+        RunOnWebView(static handle => webkit_web_view_go_back(handle));
         return true;
     }
 
@@ -218,7 +218,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             return false;
         }
 
-        RunOnGlibThreadAsync(() => webkit_web_view_go_forward(WebViewHandle));
+        RunOnWebView(static handle => webkit_web_view_go_forward(handle));
         return true;
     }
 
@@ -228,13 +228,21 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
         var gcHandle = GCHandle.Alloc(tcs);
         try
         {
-            await RunOnGlibThreadAsync(() => webkit_web_view_run_javascript(
-                WebViewHandle,
-                script,
-                IntPtr.Zero,
-                s_scriptCallback,
-                GCHandle.ToIntPtr(gcHandle)))
-                .ConfigureAwait(false);
+            await RunOnGlibThreadAsync(() =>
+            {
+                if (WebViewHandle == IntPtr.Zero)
+                {
+                    tcs.TrySetException(new InvalidOperationException("Web view was already disposed."));
+                    return;
+                }
+
+                webkit_web_view_run_javascript(
+                    WebViewHandle,
+                    script,
+                    IntPtr.Zero,
+                    s_scriptCallback,
+                    GCHandle.ToIntPtr(gcHandle));
+            }).ConfigureAwait(false);
             return await tcs.Task.ConfigureAwait(false);
         }
         finally
@@ -245,23 +253,25 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
 
     public async void Navigate(Uri url)
     {
-        await RunOnGlibThreadAsync(() => webkit_web_view_load_uri(WebViewHandle, url.ToString())).ConfigureAwait(false);
+        var uri = url.ToString();
+        await RunOnWebView(handle => webkit_web_view_load_uri(handle, uri)).ConfigureAwait(false);
     }
 
     public async void NavigateToString(string text, Uri? baseUri)
     {
-        await RunOnGlibThreadAsync(() => webkit_web_view_load_html(WebViewHandle, text, baseUri?.ToString())).ConfigureAwait(false);
+        var uri = baseUri?.ToString();
+        await RunOnWebView(handle => webkit_web_view_load_html(handle, text, uri)).ConfigureAwait(false);
     }
 
     public bool Refresh()
     {
-        RunOnGlibThreadAsync(() => webkit_web_view_reload(WebViewHandle));
+        RunOnWebView(static handle => webkit_web_view_reload(handle));
         return true;
     }
 
     public bool Stop()
     {
-        RunOnGlibThreadAsync(() => webkit_web_view_stop_loading(WebViewHandle));
+        RunOnWebView(static handle => webkit_web_view_stop_loading(handle));
         return true;
     }
 
@@ -271,9 +281,9 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
 
     public bool ShowPrintUI()
     {
-        RunOnGlibThreadAsync(() =>
+        RunOnWebView(static handle =>
         {
-            using var operation = new GtkPrintOperation(WebViewHandle);
+            using var operation = new GtkPrintOperation(handle);
             operation.RunDialog(IntPtr.Zero);
         });
         return true;
@@ -290,6 +300,11 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
         {
             await RunOnGlibThreadAsync(() =>
             {
+                if (WebViewHandle == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("Web view was already disposed.");
+                }
+
                 operation = new GtkPrintOperation(WebViewHandle);
 
                 if (settings is not null)
@@ -324,6 +339,17 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
     public virtual void SizeChanged(PixelSize containerSize)
     {
     }
+
+    private Task RunOnWebView(Action<IntPtr> action) => RunOnGlibThreadAsync(() =>
+    {
+        if (WebViewHandle != IntPtr.Zero)
+        {
+            action(WebViewHandle);
+        }
+    });
+
+    private T RunOnWebView<T>(Func<IntPtr, T> func) => RunOnGlibThread(() =>
+        WebViewHandle != IntPtr.Zero ? func(WebViewHandle) : default!);
 
     private Uri GetSourceUnsafe()
     {

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
@@ -457,7 +457,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             return;
         }
 
-        GError* err;
+        GError* err = null;
         var jsResult = webkit_web_view_run_javascript_finish(webView, result, &err);
         if (jsResult == IntPtr.Zero)
         {
@@ -601,7 +601,14 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             return null;
         }
 
-        return Marshal.PtrToStringAuto(p);
+        try
+        {
+            return Marshal.PtrToStringUTF8(p);
+        }
+        finally
+        {
+            g_free(p);
+        }
     }
 
     protected virtual void DisposeSafe(bool disposing)

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkX11WebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkX11WebViewAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -13,7 +14,7 @@ internal sealed class GtkX11WebViewAdapter : GtkWebViewAdapter, IPlatformHandle
     private static readonly IntPtr s_display = XOpenDisplay(IntPtr.Zero);
 
     private readonly IntPtr _x11Window;
-    private readonly IntPtr _windowHandle;
+    private IntPtr _windowHandle;
     private IntPtr _currentParent;
 
     private GtkX11WebViewAdapter(GtkWebViewEnvironmentRequestedEventArgs environmentArgs) : base(environmentArgs)
@@ -25,16 +26,18 @@ internal sealed class GtkX11WebViewAdapter : GtkWebViewAdapter, IPlatformHandle
         _x11Window = gdk_x11_window_get_xid(gtk_widget_get_window(_windowHandle));
     }
 
-    public static async Task<WebViewAdapter.NativeWebViewAdapterBuilder> CreateBuilder(
+    public static Task<WebViewAdapter.NativeWebViewAdapterBuilder> CreateBuilder(
         GtkWebViewEnvironmentRequestedEventArgs environmentArgs)
     {
-        var adapter = await RunOnGlibThreadAsync(() => new GtkX11WebViewAdapter(environmentArgs));
-        return (parent, _) =>
+        WebViewAdapter.NativeWebViewAdapterBuilder builder = (parent, _) =>
         {
             WebViewDispatcher.VerifyAccess();
+            var adapter = RunOnGlibThread(() => new GtkX11WebViewAdapter(environmentArgs));
             adapter.SetParent(parent);
             return new WebViewAdapter.AdapterWrapper(adapter, Task.FromResult<IWebViewAdapter>(adapter));
         };
+
+        return Task.FromResult(builder);
     }
 
     public override void SetParent(IPlatformHandle parent)
@@ -75,6 +78,22 @@ internal sealed class GtkX11WebViewAdapter : GtkWebViewAdapter, IPlatformHandle
             // gtk_widget_set_app_paintable (_windowHandle, true);
 
             base.DefaultBackground = value;
+        }
+    }
+
+    protected override void DisposeSafe(bool disposing)
+    {
+        var window = Interlocked.Exchange(ref _windowHandle, IntPtr.Zero);
+        if (window != IntPtr.Zero)
+        {
+            gtk_container_remove(window, WebViewHandle);
+        }
+
+        base.DisposeSafe(disposing);
+
+        if (window != IntPtr.Zero)
+        {
+            gtk_widget_destroy(window);
         }
     }
 

--- a/src/Avalonia.Controls.WebView.Core/Gtk/Soup3HttpHeaders.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/Soup3HttpHeaders.cs
@@ -23,7 +23,7 @@ internal sealed class Soup3HttpHeaders(IntPtr headers, bool immutable) : INative
         var userData = GCHandle.Alloc(boxedCount);
         try
         {
-            soup_message_headers_foreach(headers, &MessageHeadersForeachFunc, userData);
+            soup_message_headers_foreach(headers, &MessageHeadersForeachFunc, GCHandle.ToIntPtr(userData));
         }
         finally
         {
@@ -83,7 +83,7 @@ internal sealed class Soup3HttpHeaders(IntPtr headers, bool immutable) : INative
         var userData = GCHandle.Alloc(dictionary);
         try
         {
-            soup_message_headers_foreach(headers, &MessageHeadersForeachFunc, userData);
+            soup_message_headers_foreach(headers, &MessageHeadersForeachFunc, GCHandle.ToIntPtr(userData));
         }
         finally
         {

--- a/src/Avalonia.Controls.WebView.Core/Gtk/Soup3HttpHeaders.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/Soup3HttpHeaders.cs
@@ -47,12 +47,12 @@ internal sealed class Soup3HttpHeaders(IntPtr headers, bool immutable) : INative
 
     public string? GetHeader(string name)
     {
-        return soup_message_headers_get_list(headers, name);
+        return Marshal.PtrToStringUTF8(soup_message_headers_get_list(headers, name));
     }
 
     public bool Contains(string name)
     {
-        var value = soup_message_headers_get_one(headers, name);
+        var value = Marshal.PtrToStringUTF8(soup_message_headers_get_one(headers, name));
         return !string.IsNullOrEmpty(value);
     }
 

--- a/src/Avalonia.Controls.WebView.Core/Headless/HeadlessWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Headless/HeadlessWebViewAdapter.cs
@@ -299,6 +299,10 @@ internal partial class HeadlessWebViewAdapter : IWebViewAdapterWithOffscreenBuff
         => Task.FromResult(new HeadlessWebViewEnvironmentRequestedEventArgs.HttpResult(true, $"<html><body>HeadlessWebViewAdapter loaded {uri}</body></html>"));
 
     public event Action? DrawRequested;
+
+    public PixelFormat BufferPixelFormat => PixelFormats.Bgra8888;
+    public AlphaFormat BufferAlphaFormat => AlphaFormat.Premul;
+
     public Task UpdateWriteableBitmap(PixelSize currentSize, FrameChainBase<WriteableBitmap, PixelSize>.IProducer producer)
     {
         if (currentSize == default)

--- a/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
@@ -414,6 +414,9 @@ internal interface IWebViewAdapterWithOffscreenInput : IWebViewAdapter
 internal interface IWebViewAdapterWithOffscreenBuffer : IWebViewAdapter
 {
     event Action DrawRequested;
+    PixelFormat BufferPixelFormat { get; }
+    AlphaFormat BufferAlphaFormat { get; }
+
     Task UpdateWriteableBitmap(PixelSize currentSize, FrameChainBase<WriteableBitmap, PixelSize>.IProducer producer);
 }
 

--- a/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
@@ -591,6 +591,9 @@ internal sealed unsafe class WpeWebViewAdapter
 
     public event Action? DrawRequested;
 
+    public PixelFormat BufferPixelFormat => PixelFormats.Bgra8888;
+    public AlphaFormat BufferAlphaFormat => AlphaFormat.Premul;
+
     public Task UpdateWriteableBitmap(PixelSize currentSize, FrameChainBase<WriteableBitmap, PixelSize>.IProducer producer)
     {
         var shmBufPtr = _pendingShmExportedBuffer;

--- a/src/Avalonia.Controls.WebView.Core/Rendering/BitmapFrameChain.cs
+++ b/src/Avalonia.Controls.WebView.Core/Rendering/BitmapFrameChain.cs
@@ -3,11 +3,12 @@ using Avalonia.Platform;
 
 namespace Avalonia.Controls.Rendering;
 
-internal class BitmapFrameChain(PixelFormat? pixelFormat) : FrameChainBase<WriteableBitmap, PixelSize>
+internal class BitmapFrameChain(PixelFormat? pixelFormat, AlphaFormat? alphaFormat)
+    : FrameChainBase<WriteableBitmap, PixelSize>
 {
     protected override WriteableBitmap CreateFrame(PixelSize size)
     {
-        return new WriteableBitmap(size, new Vector(96, 96), pixelFormat);
+        return new WriteableBitmap(size, new Vector(96, 96), pixelFormat, alphaFormat);
     }
 
     protected override void FreeFrame(WriteableBitmap frame)

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2CompAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2CompAdapter.cs
@@ -128,6 +128,9 @@ internal partial class WebView2CompAdapter
         };
     }
 
+    public PixelFormat BufferPixelFormat => PixelFormats.Bgra8888;
+    public AlphaFormat BufferAlphaFormat => AlphaFormat.Premul;
+
     public async Task UpdateWriteableBitmap(PixelSize currentSize,
         FrameChainBase<WriteableBitmap, PixelSize>.IProducer producer)
     {

--- a/src/Avalonia.Controls.WebView/NativeWebView.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebView.cs
@@ -469,6 +469,7 @@ namespace Avalonia.Xpf.Controls
 
 #if AVALONIA
             VisualChildren.Add((Control)controlHostImpl);
+            InvalidateMeasure();
 #elif WPF
             IsVisibleChanged += OnIsVisibleChanged;
             var visual = (System.Windows.Media.Visual)controlHostImpl;

--- a/src/Avalonia.Controls.WebView/NativeWebViewCompositorHost.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebViewCompositorHost.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls.Rendering;
 using Avalonia.Input;
 using Avalonia.Input.TextInput;
+using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -19,9 +20,9 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
     private WebViewTextInputMethodClient? _imClient;
     private TaskCompletionSource<IWebViewAdapterWithOffscreenBuffer?>? _webViewReadyCompletion;
     //private ReparentingScope? _reparentingScope;
-    private bool _firstDraw;
     private CompositionCustomVisual? _customVisual;
     private BitmapFrameChain? _frameChain;
+    private PixelSize _adapterSize;
 
     static NativeWebViewCompositorHost()
     {
@@ -60,7 +61,21 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
         {
             _customVisual.Size = new Vector(size.Width, size.Height);
         }
+        UpdateAdapterSize(size);
         return size;
+    }
+
+    private void UpdateAdapterSize(Size size)
+    {
+        if (TryGetAdapter() is not { } adapter || TopLevel.GetTopLevel(this) is not { } topLevel)
+            return;
+
+        var pixelSize = PixelSize.FromSize(size, topLevel.RenderScaling);
+        if (pixelSize.Width <= 0 || pixelSize.Height <= 0 || pixelSize == _adapterSize)
+            return;
+
+        _adapterSize = pixelSize;
+        adapter.SizeChanged(pixelSize);
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -68,7 +83,6 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
         base.OnAttachedToVisualTree(e);
 
         var compositorVisual = ElementComposition.GetElementVisual(this)!;
-        _firstDraw = true;
         _customVisual = compositorVisual.Compositor.CreateCustomVisual(new VisualHandler());
         _customVisual.Size = new Vector(Bounds.Width, Bounds.Height);
         ElementComposition.SetElementChildVisual(this, _customVisual);
@@ -114,6 +128,7 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
 
         // Not disposed on purpose - the consumer might still be holding frames on the render thread.
         _frameChain = null;
+        _adapterSize = default;
     }
 
     private void WebViewAdapterOnInitialized(IWebViewAdapterWithOffscreenBuffer adapter)
@@ -124,7 +139,8 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
         _webViewReadyCompletion?.TrySetResult(adapter);
         AdapterCreated?.Invoke(this, adapter);
         adapter.DrawRequested += OffscreenAdapter_OnDrawRequested;
-        
+
+        UpdateAdapterSize(Bounds.Size);
         if (adapter is IWebViewAdapterWithExplicitCursor cursorAdapter)
         {
             Cursor = new Cursor(cursorAdapter.CurrentCursorType);
@@ -145,17 +161,19 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
                 return;
 
             var adapterSize = PixelSize.FromSize(Bounds.Size, topLevel.RenderScaling);
-            if (_firstDraw)
-            {
-                _firstDraw = false;
-                adapter.SizeChanged(adapterSize);
-            }
+            if (adapterSize == default)
+                return;
+
+            // Covers a draw that arrives before the host was arranged for the first time.
+            UpdateAdapterSize(Bounds.Size);
 
             await adapter.UpdateWriteableBitmap(adapterSize, _frameChain.Producer);
             _customVisual?.SendHandlerMessage(VisualHandler.DrawRequested);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Logger.TryGet(LogEventLevel.Warning, "WebView")?.Log(this,
+                "OffscreenAdapter.OnDrawRequested failed with an error: {Exception}", ex);
         }
     }
 

--- a/src/Avalonia.Controls.WebView/NativeWebViewCompositorHost.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebViewCompositorHost.cs
@@ -21,7 +21,7 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
     //private ReparentingScope? _reparentingScope;
     private bool _firstDraw;
     private CompositionCustomVisual? _customVisual;
-    private readonly BitmapFrameChain _frameChain = new(PixelFormats.Bgra8888);
+    private BitmapFrameChain? _frameChain;
 
     static NativeWebViewCompositorHost()
     {
@@ -67,16 +67,15 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
     {
         base.OnAttachedToVisualTree(e);
 
-        _webViewReadyCompletion = new TaskCompletionSource<IWebViewAdapterWithOffscreenBuffer?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var adapterTask = factory.InvokeAsync(this);
-        CompleteAdapter();
-
         var compositorVisual = ElementComposition.GetElementVisual(this)!;
         _firstDraw = true;
         _customVisual = compositorVisual.Compositor.CreateCustomVisual(new VisualHandler());
         _customVisual.Size = new Vector(Bounds.Width, Bounds.Height);
-        _customVisual.SendHandlerMessage(_frameChain.Consumer);
         ElementComposition.SetElementChildVisual(this, _customVisual);
+
+        _webViewReadyCompletion = new TaskCompletionSource<IWebViewAdapterWithOffscreenBuffer?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var adapterTask = factory.InvokeAsync(this);
+        CompleteAdapter();
 
         // ReSharper disable once AsyncVoidMethod - let it flow to the dispatcher
         async void CompleteAdapter()
@@ -112,10 +111,16 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
             ElementComposition.SetElementChildVisual(this, null);
             _customVisual = null;
         }
+
+        // Not disposed on purpose - the consumer might still be holding frames on the render thread.
+        _frameChain = null;
     }
 
     private void WebViewAdapterOnInitialized(IWebViewAdapterWithOffscreenBuffer adapter)
     {
+        _frameChain = new BitmapFrameChain(adapter.BufferPixelFormat, adapter.BufferAlphaFormat);
+        _customVisual?.SendHandlerMessage(_frameChain.Consumer);
+
         _webViewReadyCompletion?.TrySetResult(adapter);
         AdapterCreated?.Invoke(this, adapter);
         adapter.DrawRequested += OffscreenAdapter_OnDrawRequested;
@@ -132,7 +137,7 @@ internal class NativeWebViewCompositorHost(WebViewAdapter.CompositorHostAdapterF
         try
         {
             var adapter = (IWebViewAdapterWithOffscreenBuffer?)TryGetAdapter();
-            if (adapter is null)
+            if (adapter is null || _frameChain is null)
                 return;
 
             var topLevel = TopLevel.GetTopLevel(this);

--- a/tests/Avalonia.Controls.WebView.Tests/BitmapFrameChainTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/BitmapFrameChainTests.cs
@@ -1,0 +1,52 @@
+using System.Runtime.InteropServices;
+using Avalonia.Controls.Rendering;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Controls.WebView.Tests;
+
+public class BitmapFrameChainTests
+{
+    [AvaloniaFact]
+    public void Frames_Are_Allocated_In_The_Requested_Format()
+    {
+        var chain = new BitmapFrameChain(PixelFormats.Rgba8888, AlphaFormat.Unpremul);
+
+        using (chain.Producer.GetNextFrame(new PixelSize(4, 4), out var frame))
+        {
+            Assert.Equal(PixelFormats.Rgba8888, frame.Format);
+            Assert.Equal(AlphaFormat.Unpremul, frame.AlphaFormat);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Rgba_Frames_Keep_The_Channel_Order_Of_The_Source_Buffer()
+    {
+        var chain = new BitmapFrameChain(PixelFormats.Rgba8888, AlphaFormat.Unpremul);
+        using var destination = new WriteableBitmap(
+            new PixelSize(1, 1), new Vector(96, 96), PixelFormats.Bgra8888, AlphaFormat.Premul);
+
+        using (chain.Producer.GetNextFrame(new PixelSize(1, 1), out var frame))
+        {
+            using (var frameBuffer = frame.Lock())
+            {
+                // #FFFF00 as GdkPixbuf stores it.
+                Marshal.Copy(new byte[] { 0xFF, 0xFF, 0x00, 0xFF }, 0, frameBuffer.Address, 4);
+            }
+
+            using var destinationBuffer = destination.Lock();
+            frame.CopyPixels(destinationBuffer);
+        }
+
+        var pixel = new byte[4];
+        using (var destinationBuffer = destination.Lock())
+        {
+            Marshal.Copy(destinationBuffer.Address, pixel, 0, 4);
+        }
+
+        // #FFFF00 as Bgra8888 stores it.
+        Assert.Equal([0x00, 0xFF, 0xFF, 0xFF], pixel);
+    }
+}

--- a/tests/Avalonia.Controls.WebView.Tests/HeadlessAdapterTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/HeadlessAdapterTests.cs
@@ -331,6 +331,44 @@ public class HeadlessAdapterTests : HeadlessTestsBase
         Assert.Equal(second, webView.Source);
     }
 
+    [AvaloniaFact]
+    public async Task NativeWebView_Offscreen_Host_Is_Laid_Out_After_Adapter_Creation()
+    {
+        var window = new Window { Width = 400, Height = 300 };
+        var webView = new NativeWebView();
+        webView.EnvironmentRequested += (_, _) => { };
+        window.Content = webView;
+        window.Show();
+
+        await WaitForAdapterCreation(webView);
+        await DoDelay();
+
+        var host = webView.GetVisualChildren().OfType<Control>().Single();
+        Assert.True(host.Bounds.Width > 0 && host.Bounds.Height > 0,
+            $"Host was not laid out: {host.Bounds}, web view: {webView.Bounds}");
+    }
+
+    [AvaloniaFact]
+    public async Task NativeWebView_Reattach_Creates_A_New_Adapter()
+    {
+        var (window, panel, webView) = CreateReattachableWebView();
+        window.Show();
+
+        await WaitForAdapterCreation(webView);
+        var first = webView.TryGetPlatformHandle();
+        Assert.NotNull(first);
+
+        var destroyed = false;
+        webView.AdapterDestroyed += (_, _) => destroyed = true;
+
+        await ReattachAsync(panel, webView);
+
+        Assert.True(destroyed);
+        var second = webView.TryGetPlatformHandle();
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+    }
+
     private static (Window window, StackPanel panel, NativeWebView webView) CreateReattachableWebView()
     {
         var panel = new StackPanel();


### PR DESCRIPTION
Fixes https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/56

1. GTK Offscreen rendering used wrong pixel format
2. GTK Offscreen wasn't rendered until first resize
3. Both offscreen and non-offscreen backend wasn't properly disposed, and it was reusing the same webview handle on re-attaching.
4. Several PInvokes were incorrectly defined (it was manually defined before AI era with static analysis, funny how much easier pinvokes are now)