### PR TITLE
Fix WebView2 memory leak

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/CoreWebView2Environment.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/CoreWebView2Environment.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using System.Runtime.Versioning;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls.Win.WebView2.Interop;
 using Avalonia.Logging;
@@ -16,8 +17,13 @@ namespace Avalonia.Controls.Win.WebView2;
 internal static partial class CoreWebView2Environment
 {
     private enum WebView2RunTimeType { kInstalled = 0x0, kRedistributable = 0x1 }
+    private static readonly Dictionary<EnvironmentOptions, EnvironmentEntry> s_environments = new();
 
-    private static readonly Dictionary<EnvironmentOptions, TaskCompletionSource<ICoreWebView2Environment>> s_environments = new();
+    private sealed class EnvironmentEntry
+    {
+        public Task<ICoreWebView2Environment>? Pending;
+        public WeakReference<ICoreWebView2Environment>? Created;
+    }
 
     public static Task<ICoreWebView2Environment> CreateAsync(WindowsWebView2EnvironmentRequestedEventArgs environmentArgs)
     {
@@ -37,30 +43,50 @@ internal static partial class CoreWebView2Environment
 
     private static Task<ICoreWebView2Environment> GetOrCreateEnvForOptions(EnvironmentOptions options)
     {
-        if (!s_environments.TryGetValue(options, out var tcs))
+        if (!s_environments.TryGetValue(options, out var entry))
         {
-            var runtimeFunc = TryFindWebView2Runtime(options.BrowserExecutableFolder);
-            if (runtimeFunc == IntPtr.Zero)
-            {
-                tcs = new TaskCompletionSource<ICoreWebView2Environment>(TaskCreationOptions.RunContinuationsAsynchronously);
-                tcs.SetException(new InvalidOperationException("WebView2 runtime not found or CreateWebViewEnvironmentWithOptionsInternal not exported."));
-            }
-            else
-            {
-                var envCallback = new WebView2EnvHandler();
-                var res = (uint)CreateEnv(runtimeFunc, WebView2RunTimeType.kInstalled, options.UserDataFolder, options, envCallback);
-                if (res == 0x80010106)
-                {
-                    envCallback.Result.TrySetException(new InvalidOperationException("WebView2 requires UI thread to have STAThread flag/attribute set."));
-                }
-                else if (res != 0)
-                {
-                    envCallback.Result.TrySetException(Marshal.GetExceptionForHR((int)res) ?? new Win32Exception((int)res));
-                }
-                tcs = envCallback.Result;
-            }
-            s_environments[options] = tcs;
+            s_environments[options] = entry = new EnvironmentEntry();
         }
+        else if (entry.Created is { } created && created.TryGetTarget(out var env))
+        {
+            return Task.FromResult(env);
+        }
+        else if (entry.Pending is { } pending)
+        {
+            return pending;
+        }
+
+        TaskCompletionSource<ICoreWebView2Environment> tcs;
+        var runtimeFunc = TryFindWebView2Runtime(options.BrowserExecutableFolder);
+        if (runtimeFunc == IntPtr.Zero)
+        {
+            tcs = new TaskCompletionSource<ICoreWebView2Environment>(TaskCreationOptions.RunContinuationsAsynchronously);
+            tcs.SetException(new InvalidOperationException("WebView2 runtime not found or CreateWebViewEnvironmentWithOptionsInternal not exported."));
+        }
+        else
+        {
+            var envCallback = new WebView2EnvHandler();
+            var res = (uint)CreateEnv(runtimeFunc, WebView2RunTimeType.kInstalled, options.UserDataFolder, options, envCallback);
+            if (res == 0x80010106)
+            {
+                envCallback.Result.TrySetException(new InvalidOperationException("WebView2 requires UI thread to have STAThread flag/attribute set."));
+            }
+            else if (res != 0)
+            {
+                envCallback.Result.TrySetException(Marshal.GetExceptionForHR((int)res) ?? new Win32Exception((int)res));
+            }
+            tcs = envCallback.Result;
+        }
+
+        entry.Created = null;
+        entry.Pending = tcs.Task;
+
+        _ = tcs.Task.ContinueWith(static (task, state) =>
+        {
+            var entry = (EnvironmentEntry)state!;
+            entry.Pending = null;
+            entry.Created = task.IsCompletedSuccessfully ? new WeakReference<ICoreWebView2Environment>(task.Result) : null;
+        }, entry, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
         return tcs.Task;
     }

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using System.Runtime.Versioning;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -426,12 +427,14 @@ internal abstract partial class WebView2BaseAdapter(ICoreWebView2Controller cont
 
     protected virtual void Dispose(bool disposing)
     {
-        if (disposing)
+        if (!disposing || Disposed)
         {
-            Disposed = true;
-            controller?.Close();
-            _subscriptions?.Invoke();
+            return;
         }
+
+        Disposed = true;
+        Interlocked.Exchange(ref _subscriptions, null)?.Invoke();
+        controller?.Close();
     }
 
     public void Dispose()

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2CompAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2CompAdapter.cs
@@ -279,7 +279,7 @@ internal partial class WebView2CompAdapter
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing)
+        if (disposing && !Disposed)
         {
             _controller.SetRootVisualTarget(null);
         }

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2HwndAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2HwndAdapter.cs
@@ -2,6 +2,8 @@
 using System.Runtime.InteropServices.Marshalling;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 using Avalonia.Controls.Win.WebView2.Interop;
 using Avalonia.Platform;
 
@@ -13,6 +15,14 @@ internal partial class WebView2HwndAdapter(IPlatformHandle handle, ICoreWebView2
 {
     public override IntPtr Handle { get; } = handle.Handle;
     public override string HandleDescriptor { get; } = handle.HandleDescriptor!; // Expected to be HWND always.
+
+    public override void SetParent(IPlatformHandle parent)
+    {
+        if (parent.HandleDescriptor != "HWND")
+            throw new InvalidOperationException("IPlatformHandle.HandleDescriptor must be HWND");
+
+        PInvoke.SetParent(new HWND(Handle), new HWND(parent.Handle));
+    }
 
     public static async Task<WebViewAdapter.NativeWebViewAdapterBuilder> CreateBuilder(
         WindowsWebView2EnvironmentRequestedEventArgs environmentArgs)

--- a/src/Avalonia.Controls.WebView/NativeWebViewControlHost.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebViewControlHost.cs
@@ -1,6 +1,5 @@
 #if AVALONIA || WPF
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using IPlatformHandle = Avalonia.Platform.IPlatformHandle;
 using Core = Avalonia.Controls;
@@ -23,6 +22,7 @@ namespace Avalonia.Xpf.Controls
     {
         private TaskCompletionSource<IWebViewAdapter?>? _webViewReadyCompletion;
         private ReparentingScope? _reparentingScope;
+        private IPlatformHandle? _defaultChildHandle;
 
         /// <inheritdoc />
         public event EventHandler<IWebViewAdapter>? AdapterCreated;
@@ -37,11 +37,12 @@ namespace Avalonia.Xpf.Controls
                 return _reparentingScope.ReparentRequested(parent);
             }
 
-            _webViewReadyCompletion = new TaskCompletionSource<IWebViewAdapter?>(TaskCreationOptions.RunContinuationsAsynchronously);
             var completion = _webViewReadyCompletion =
                 new TaskCompletionSource<IWebViewAdapter?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var adapterWrapper = factory.InvokeAsync(parent, p => base.CreateNativeControlCore(p));
+            IPlatformHandle? defaultChildHandle = null;
+            var adapterWrapper = factory.InvokeAsync(parent, p => defaultChildHandle = base.CreateNativeControlCore(p));
+            _defaultChildHandle = defaultChildHandle;
             CompleteAdapter(adapterWrapper);
             return adapterWrapper.AdapterHandle;
 
@@ -70,20 +71,26 @@ namespace Avalonia.Xpf.Controls
 
         protected override void DestroyNativeControlCore(IPlatformHandle control)
         {
-            if (control is IWebViewAdapter adapter)
+            var adapter = TryGetAdapter();
+            if (adapter is not null && _reparentingScope is not null)
             {
-                if (_reparentingScope is not null)
-                {
-                    _reparentingScope.SetDestroyingAdapter(adapter);
-                    return;
-                }
+                _reparentingScope.SetDestroyingAdapter(adapter);
+                return;
+            }
 
-                Debug.Assert(!(TryGetAdapter() is { } oldAdapter && oldAdapter != adapter));
+            _webViewReadyCompletion?.TrySetCanceled();
+            _webViewReadyCompletion = null;
 
-                _webViewReadyCompletion?.TrySetCanceled();
-                _webViewReadyCompletion = null;
+            if (adapter is not null)
+            {
                 AdapterDestroyed?.Invoke(this, adapter);
                 adapter.Dispose();
+            }
+
+            if (_defaultChildHandle is { } defaultChildHandle)
+            {
+                _defaultChildHandle = null;
+                base.DestroyNativeControlCore(defaultChildHandle);
             }
         }
 

--- a/src/Avalonia.Controls.WebView/NativeWebViewControlHost.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebViewControlHost.cs
@@ -38,6 +38,8 @@ namespace Avalonia.Xpf.Controls
             }
 
             _webViewReadyCompletion = new TaskCompletionSource<IWebViewAdapter?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var completion = _webViewReadyCompletion =
+                new TaskCompletionSource<IWebViewAdapter?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var adapterWrapper = factory.InvokeAsync(parent, p => base.CreateNativeControlCore(p));
             CompleteAdapter(adapterWrapper);
@@ -47,6 +49,12 @@ namespace Avalonia.Xpf.Controls
             async void CompleteAdapter(WebViewAdapter.AdapterWrapper wrapper)
             {
                 var adapter = await wrapper.AdapterInitializeTask;
+                if (!ReferenceEquals(_webViewReadyCompletion, completion))
+                {
+                    adapter.Dispose();
+                    return;
+                }
+
                 WebViewAdapterOnInitialized(adapter);
             }
         }

--- a/src/Avalonia.Controls.WebView/WindowNativeWebViewDialog.cs
+++ b/src/Avalonia.Controls.WebView/WindowNativeWebViewDialog.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Xpf.Controls
             }
         }
 
-        public void Dispose() {}
+        public void Dispose() => Close();
 
         event EventHandler? Core.INativeWebViewDialog.Closing
         {


### PR DESCRIPTION
Fixes https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/44

Two main issues:
- Environment instance was GC rooted and never collected
- If `NativeControlHost.CreateDefaultChild` was called - this child was not released