### PR TITLE
Move adapter resizing from NativeWebView to NativeWebViewControlHost

### DIFF
--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
@@ -397,7 +397,11 @@ public partial class MainView : UserControl
             Source = Uri.TryCreate(GridWebViewSource.Text, UriKind.Absolute, out var source) ?
                 source :
                 new Uri("about:blank"),
-            Title = "Avalonia WebView Demo" 
+            Title = "Avalonia WebView Demo"
+        };
+        dialog.EnvironmentRequested += (_, args) =>
+        {
+            args.EnableDevTools = true;
         };
         dialog.Show();
     }

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkX11WebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkX11WebViewAdapter.cs
@@ -16,6 +16,7 @@ internal sealed class GtkX11WebViewAdapter : GtkWebViewAdapter, IPlatformHandle
     private readonly IntPtr _x11Window;
     private IntPtr _windowHandle;
     private IntPtr _currentParent;
+    private PixelSize _sizeRequest;
 
     private GtkX11WebViewAdapter(GtkWebViewEnvironmentRequestedEventArgs environmentArgs) : base(environmentArgs)
     {
@@ -69,6 +70,21 @@ internal sealed class GtkX11WebViewAdapter : GtkWebViewAdapter, IPlatformHandle
 
             RunOnGlibThreadAsync(() => gtk_widget_show_all(_windowHandle));
         }
+    }
+
+    public override void SizeChanged(PixelSize containerSize)
+    {
+        if (containerSize.Width <= 0 || containerSize.Height <= 0)
+            return;
+
+        _sizeRequest = containerSize;
+        RunOnGlibThreadAsync(() =>
+        {
+            if (_windowHandle == IntPtr.Zero)
+                return;
+
+            gtk_window_resize(_windowHandle, _sizeRequest.Width, _sizeRequest.Height);
+        });
     }
 
     public override Color DefaultBackground

--- a/src/Avalonia.Controls.WebView/NativeWebView.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebView.cs
@@ -694,12 +694,6 @@ namespace Avalonia.Xpf.Controls
             }
         }
 
-        protected override void OnSizeChanged(SizeChangedEventArgs e)
-        {
-            base.OnSizeChanged(e);
-            TryGetAdapter()?.SizeChanged(PixelSize.FromSize(e.NewSize, GetRenderScaling()));
-        }
-
         private void EnsureBackground(IBrush? background)
         {
             if (TryGetAdapter() is { } adapter)

--- a/src/Avalonia.Controls.WebView/NativeWebViewControlHost.cs
+++ b/src/Avalonia.Controls.WebView/NativeWebViewControlHost.cs
@@ -23,6 +23,9 @@ namespace Avalonia.Xpf.Controls
         private TaskCompletionSource<IWebViewAdapter?>? _webViewReadyCompletion;
         private ReparentingScope? _reparentingScope;
         private IPlatformHandle? _defaultChildHandle;
+#if AVALONIA
+        private PixelSize _adapterSize;
+#endif
 
         /// <inheritdoc />
         public event EventHandler<IWebViewAdapter>? AdapterCreated;
@@ -80,6 +83,9 @@ namespace Avalonia.Xpf.Controls
 
             _webViewReadyCompletion?.TrySetCanceled();
             _webViewReadyCompletion = null;
+#if AVALONIA
+            _adapterSize = default;
+#endif
 
             if (adapter is not null)
             {
@@ -108,6 +114,28 @@ namespace Avalonia.Xpf.Controls
             }
 #endif
         }
+
+#if AVALONIA
+        protected override void OnSizeChanged(SizeChangedEventArgs e)
+        {
+            base.OnSizeChanged(e);
+            UpdateAdapterSize(e.NewSize);
+        }
+
+        // Native control host only moves and resizes the native handle, the adapter needs to be notified separately.
+        private void UpdateAdapterSize(Size size)
+        {
+            if (TryGetAdapter() is not { } adapter || TopLevel.GetTopLevel(this) is not { } topLevel)
+                return;
+
+            var pixelSize = PixelSize.FromSize(size, topLevel.RenderScaling);
+            if (pixelSize.Width <= 0 || pixelSize.Height <= 0 || pixelSize == _adapterSize)
+                return;
+
+            _adapterSize = pixelSize;
+            adapter.SizeChanged(pixelSize);
+        }
+#endif
 
         /// <inheritdoc />
         public IDisposable BeginReparenting(bool yieldOnLayoutBeforeExiting = true)


### PR DESCRIPTION
For consistency with offscreen implementation, and to fix dialog resize events not being reached to the native code.
Also re-enables GTK SizeChanged notification handling.

Fixes https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/32
Fixes https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/48