### PR TITLE
HTTP local server fallback for WebAuthenticationBroker

### DIFF
--- a/Avalonia.Controls.WebView.slnx
+++ b/Avalonia.Controls.WebView.slnx
@@ -25,6 +25,13 @@
     <Project Path="samples/Avalonia.Xpf.Controls.WebView.Samples/Avalonia.Xpf.Controls.WebView.Samples.csproj" />
     <Project Path="samples/NativeWebViewTest/NativeWebViewTest.csproj" />
   </Folder>
+  <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path=".gitignore" />
+    <File Path=".gitmodules" />
+    <File Path="LICENSE" />
+    <File Path="Readme.md" />
+  </Folder>
   <Folder Name="/Tests/">
     <Project Path="tests/Avalonia.Controls.WebView.Tests/Avalonia.Controls.WebView.Tests.csproj" />
   </Folder>

--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml
@@ -125,6 +125,12 @@
                 <TextBox x:Name="RedirectUri"
                          UseFloatingPlaceholder="True"
                          PlaceholderText="Redirect Uri" />
+                <ComboBox x:Name="AuthMode"
+                          SelectedIndex="0">
+                    <ComboBoxItem Content="Default" />
+                    <ComboBoxItem Content="NativeWebDialog" />
+                    <ComboBoxItem Content="SystemBrowser" />
+                </ComboBox>
                 <Button Content="Go" Click="WebAuthenticationBrokerButton_OnClick" />
                 <TextBox x:Name="CallbackUri"
                          AcceptsReturn="True"

--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml
@@ -127,9 +127,10 @@
                          PlaceholderText="Redirect Uri" />
                 <ComboBox x:Name="AuthMode"
                           SelectedIndex="0">
-                    <ComboBoxItem Content="Default" />
+                    <ComboBoxItem Content="Auto" />
+                    <ComboBoxItem Content="System" />
                     <ComboBoxItem Content="NativeWebDialog" />
-                    <ComboBoxItem Content="SystemBrowser" />
+                    <ComboBoxItem Content="Browser" />
                 </ComboBox>
                 <Button Content="Go" Click="WebAuthenticationBrokerButton_OnClick" />
                 <TextBox x:Name="CallbackUri"

--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
@@ -239,7 +239,8 @@ public partial class MainView : UserControl
                 {
                     // The loopback listener is reachable by any local process, so ignore anything that
                     // doesn't carry the state we sent instead of letting it end the flow.
-                    CallbackFilter = uri => HttpUtility.ParseQueryString(uri.Query)["state"] == state
+                    CallbackFilter = result =>
+                        HttpUtility.ParseQueryString(result.CallbackUri.Query)["state"] == state
                 }
             };
 

--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
@@ -221,8 +221,9 @@ public partial class MainView : UserControl
 #pragma warning disable CA1416
                 Mode = AuthMode.SelectedIndex switch
                 {
-                    1 => WebAuthenticatorMode.NativeWebDialog,
-                    2 => WebAuthenticatorMode.Browser,
+                    1 => WebAuthenticatorMode.System,
+                    2 => WebAuthenticatorMode.NativeWebDialog,
+                    3 => WebAuthenticatorMode.Browser,
                     _ => WebAuthenticatorMode.Auto
                 }
 #pragma warning restore CA1416

--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
@@ -214,7 +214,19 @@ public partial class MainView : UserControl
 #elif WPF
             var topLevel = Window.GetWindow(this);
 #endif
-            var options = new WebAuthenticatorOptions(new Uri(RequestUri.Text!), new Uri(RedirectUri.Text!, UriKind.RelativeOrAbsolute));
+            var requestUri = new Uri(RequestUri.Text!);
+            var options = new WebAuthenticatorOptions(requestUri, new Uri(RedirectUri.Text!, UriKind.RelativeOrAbsolute))
+            {
+                // The combo box order doesn't match the enum order, so map it explicitly.
+#pragma warning disable CA1416
+                Mode = AuthMode.SelectedIndex switch
+                {
+                    1 => WebAuthenticatorMode.NativeWebDialog,
+                    2 => WebAuthenticatorMode.Browser,
+                    _ => WebAuthenticatorMode.Auto
+                }
+#pragma warning restore CA1416
+            };
 
             var result = await WebAuthenticationBroker.AuthenticateAsync(topLevel!, options);
 
@@ -236,7 +248,7 @@ public partial class MainView : UserControl
                 "com.AvaloniaUI.WebView.Samples:/oauth2redirect" :
                 OperatingSystem.IsBrowser() ?
                     href?.TrimEnd('/') + "/oauth2redirect" :
-                    "http://localhost";
+                    "http://127.0.0.1";
         var clientId = OperatingSystem.IsIOS() ?
             "457602913817-kd2547t40mrvqi63c4m7lphs5s6s5lt2.apps.googleusercontent.com" :
             OperatingSystem.IsAndroid() ?

--- a/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
+++ b/samples/Avalonia.Controls.WebView.Samples/MainView.axaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 #if AVALONIA
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -215,9 +216,16 @@ public partial class MainView : UserControl
             var topLevel = Window.GetWindow(this);
 #endif
             var requestUri = new Uri(RequestUri.Text!);
+
+            // Read the state back out of the request we are about to send, so an edited request uri
+            // stays consistent with the filter below.
+            var state = HttpUtility.ParseQueryString(requestUri.Query)["state"];
+
             var options = new WebAuthenticatorOptions(requestUri, new Uri(RedirectUri.Text!, UriKind.RelativeOrAbsolute))
             {
                 // The combo box order doesn't match the enum order, so map it explicitly.
+                // CA1416: this sample targets plain net10.0, so every mode looks reachable on every
+                // platform. Picking an unsupported one throws PlatformNotSupportedException at runtime.
 #pragma warning disable CA1416
                 Mode = AuthMode.SelectedIndex switch
                 {
@@ -225,8 +233,14 @@ public partial class MainView : UserControl
                     2 => WebAuthenticatorMode.NativeWebDialog,
                     3 => WebAuthenticatorMode.Browser,
                     _ => WebAuthenticatorMode.Auto
-                }
+                },
 #pragma warning restore CA1416
+                BrowserOptions = new BrowserOptions
+                {
+                    // The loopback listener is reachable by any local process, so ignore anything that
+                    // doesn't carry the state we sent instead of letting it end the flow.
+                    CallbackFilter = uri => HttpUtility.ParseQueryString(uri.Query)["state"] == state
+                }
             };
 
             var result = await WebAuthenticationBroker.AuthenticateAsync(topLevel!, options);
@@ -261,6 +275,7 @@ public partial class MainView : UserControl
         var requestUri = "https://accounts.google.com/o/oauth2/auth?response_type=code&access_type=offline&scope=openid";
         requestUri += "&client_id=" + clientId;
         requestUri += "&redirect_uri=" + redirectUri;
+        requestUri += "&state=" + Guid.NewGuid().ToString("N");
         return (requestUri, redirectUri);
     }
 

--- a/samples/Avalonia.Xpf.Controls.WebView.Samples/MainView.xaml
+++ b/samples/Avalonia.Xpf.Controls.WebView.Samples/MainView.xaml
@@ -132,6 +132,12 @@
             <StackPanel>
                 <TextBox x:Name="RequestUri" />
                 <TextBox x:Name="RedirectUri" />
+                <ComboBox x:Name="AuthMode"
+                          SelectedIndex="0">
+                    <ComboBoxItem Content="Default" />
+                    <ComboBoxItem Content="NativeWebDialog" />
+                    <ComboBoxItem Content="SystemBrowser" />
+                </ComboBox>
                 <Button Content="Go" Click="WebAuthenticationBrokerButton_OnClick" />
                 <TextBox x:Name="CallbackUri"
                          AcceptsReturn="True" />

--- a/src/Avalonia.Controls.WebView.Core/Authentication/BrowserResponse.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/BrowserResponse.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using System.Net;
+
+namespace Avalonia.Controls.Authentication;
+
+/// <summary>
+/// Represents the HTTP response sent to the browser after the authentication callback is received.
+/// </summary>
+public sealed class BrowserResponse
+{
+    private Uri? _redirect;
+    internal BrowserResponse(Stream outputStream)
+    {
+        StatusCode = HttpStatusCode.OK;
+        OutputStream = outputStream;
+    }
+
+    /// <summary>
+    /// Gets or sets the HTTP status code of the response.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; set; }
+
+    /// <summary>
+    /// Gets the stream to which the response content can be written.
+    /// </summary>
+    public Stream OutputStream { get; }
+
+    /// <summary>
+    /// Configures the response to redirect the browser to the specified URI.
+    /// </summary>
+    public void Redirect(Uri uri)
+    {
+        _redirect = uri;
+        StatusCode = HttpStatusCode.Found;
+    }
+
+    internal Uri? ReadRedirect() => _redirect;
+}

--- a/src/Avalonia.Controls.WebView.Core/Authentication/BrowserResponse.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/BrowserResponse.cs
@@ -28,9 +28,20 @@ public sealed class BrowserResponse
 
     /// <summary>
     /// Configures the response to redirect the browser to the specified URI.
+    /// Sets <see cref="StatusCode"/> to <see cref="HttpStatusCode.Found"/>.
     /// </summary>
+    /// <param name="uri">Absolute uri to redirect the browser to.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="uri"/> is not absolute.</exception>
     public void Redirect(Uri uri)
     {
+        ArgumentNullException.ThrowIfNull(uri);
+
+        if (!uri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("Redirect uri must be absolute.", nameof(uri));
+        }
+
         _redirect = uri;
         StatusCode = HttpStatusCode.Found;
     }

--- a/src/Avalonia.Controls.WebView.Core/Authentication/LoopbackHttpListener.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/LoopbackHttpListener.cs
@@ -25,17 +25,26 @@ internal sealed class LoopbackHttpListener : IDisposable
     private const int HttpRequestBufferSize = 4096;
 
     private readonly TcpListener _listener;
+    private readonly string _host;
     private readonly string _redirectPath;
 
     /// <summary>
     /// Starts a listener on the loopback interface.
     /// </summary>
-    /// <param name="port">Port to listen on, or 0 to let the OS allocate a free one.</param>
-    /// <param name="redirectPath">Relative redirect path (e.g. <c>/callback</c>) that completes the flow.</param>
-    public LoopbackHttpListener(int port, string redirectPath)
+    /// <param name="redirectUri">
+    /// Redirect uri to serve.
+    /// Its host selects the loopback address to bind and is reported back in the callback uri.
+    /// Its port is used when specified, otherwise the OS allocates a free one.
+    /// </param>
+    public LoopbackHttpListener(Uri redirectUri)
     {
-        _listener = new TcpListener(IPAddress.Loopback, port) { ExclusiveAddressUse = true };
-        _redirectPath = redirectPath;
+        _host = redirectUri.Host;
+        _redirectPath = redirectUri.AbsolutePath;
+
+        var address = ResolveBindAddress(redirectUri);
+        var port = redirectUri.IsDefaultPort ? 0 : redirectUri.Port;
+
+        _listener = new TcpListener(address, port) { ExclusiveAddressUse = true };
 
         try
         {
@@ -43,11 +52,15 @@ internal sealed class LoopbackHttpListener : IDisposable
         }
         catch (Exception ex)
         {
-            var actualPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
             throw new InvalidOperationException(
-                $"Failed to start the local callback listener on 127.0.0.1:{actualPort}.", ex);
+                $"Failed to start the local callback listener on {address}:{port}.", ex);
         }
     }
+
+    private static IPAddress ResolveBindAddress(Uri redirectUri) =>
+        IPAddress.TryParse(redirectUri.DnsSafeHost, out var address) && IPAddress.IsLoopback(address)
+            ? address
+            : IPAddress.Loopback;
 
     /// <summary>
     /// Port the listener is actually bound to.
@@ -127,7 +140,7 @@ internal sealed class LoopbackHttpListener : IDisposable
         }
     }
 
-    private static async Task<Uri?> ReadRequestUriAsync(TcpClient client, CancellationToken cancellationToken)
+    private async Task<Uri?> ReadRequestUriAsync(TcpClient client, CancellationToken cancellationToken)
     {
         var stream = client.GetStream();
         using var reader = new StreamReader(stream, Encoding.ASCII,
@@ -155,18 +168,9 @@ internal sealed class LoopbackHttpListener : IDisposable
         if (rawTarget.Length == 0 || rawTarget[0] != '/')
             return null;
 
-        // The authority comes from the accepted socket, never from the request's Host header: any local
-        // process can connect to the loopback port and send an arbitrary Host, which would otherwise end
-        // up as the authority of the uri handed back to the application.
-        var authority = client.Client.LocalEndPoint is IPEndPoint localEndPoint
-            ? localEndPoint.AddressFamily == AddressFamily.InterNetworkV6
-                ? $"[{localEndPoint.Address}]:{localEndPoint.Port}"
-                : $"{localEndPoint.Address}:{localEndPoint.Port}"
-            : "127.0.0.1";
-
-        // Reconstruct a full URI from the request target, so downstream redirect uri handling
-        // keeps the correct host and port.
-        return Uri.TryCreate($"http://{authority}{rawTarget}", UriKind.Absolute, out var uri) ? uri : null;
+        // The authority is the host the application configured plus the port actually bound.
+        // It never comes from the request's Host header.
+        return Uri.TryCreate($"http://{_host}:{Port}{rawTarget}", UriKind.Absolute, out var uri) ? uri : null;
     }
 
     private static async Task SendResponseAsync(

--- a/src/Avalonia.Controls.WebView.Core/Authentication/LoopbackHttpListener.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/LoopbackHttpListener.cs
@@ -1,0 +1,247 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Avalonia.Controls.Authentication;
+
+/// <summary>
+/// Local HTTP listener that captures an OAuth redirect callback from the browser.
+/// </summary>
+/// <remarks>
+/// Uses <see cref="TcpListener"/> bound to the loopback address rather than <see cref="HttpListener"/>.
+/// <see cref="HttpListener"/> on macOS does not reliably accept connections when its prefix contains a
+/// literal IP address such as <c>http://127.0.0.1:port/</c>, causing the browser redirect to fail with a
+/// "Can't Connect to the Server" error. <see cref="TcpListener"/> binds directly to the desired
+/// <see cref="IPEndPoint"/> and avoids this platform specific limitation.
+/// </remarks>
+[UnsupportedOSPlatform("browser")]
+internal sealed class LoopbackHttpListener : IDisposable
+{
+    private const int HttpRequestBufferSize = 4096;
+
+    private readonly TcpListener _listener;
+    private readonly string _redirectPath;
+
+    /// <summary>
+    /// Starts a listener on the loopback interface.
+    /// </summary>
+    /// <param name="port">Port to listen on, or 0 to let the OS allocate a free one.</param>
+    /// <param name="redirectPath">Relative redirect path (e.g. <c>/callback</c>) that completes the flow.</param>
+    public LoopbackHttpListener(int port, string redirectPath)
+    {
+        _listener = new TcpListener(IPAddress.Loopback, port) { ExclusiveAddressUse = true };
+        _redirectPath = redirectPath;
+
+        try
+        {
+            _listener.Start();
+        }
+        catch (Exception ex)
+        {
+            var actualPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            throw new InvalidOperationException(
+                $"Failed to start the local callback listener on 127.0.0.1:{actualPort}.", ex);
+        }
+    }
+
+    /// <summary>
+    /// Port the listener is actually bound to.
+    /// </summary>
+    public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+    public async Task<Uri> WaitForCallbackAsync(
+        Func<Uri, BrowserResponse, Task>? responseFactory,
+        CancellationToken cancellationToken)
+    {
+        // Keep looping until the HTTP client sends a matching request.
+        // Browsers can send OPTIONS or favicon.ico first, before the expected callback.
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                var requestUri = await ReadRequestUriAsync(client, cancellationToken).ConfigureAwait(false);
+                if (requestUri is null)
+                    continue;
+
+                var found = requestUri.AbsolutePath == _redirectPath;
+
+                BrowserResponse? response;
+                if (found && responseFactory is not null)
+                {
+                    var stream = new MemoryStream();
+                    response = new BrowserResponse(stream);
+                    await responseFactory(requestUri, response).ConfigureAwait(false);
+                }
+                else
+                {
+                    response = found ? BuildDefaultResponse(HttpStatusCode.OK) : BuildDefaultResponse(HttpStatusCode.NotFound);
+                }
+
+                await SendResponseAsync(client, response, cancellationToken).ConfigureAwait(false);
+                if (found)
+                {
+                    return requestUri;
+                }
+            }
+            catch (IOException)
+            {
+                // Client disconnected or sent a malformed request; wait for the next one.
+            }
+            catch (SocketException)
+            {
+                // Client disconnected; wait for the next one.
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _listener.Dispose();
+        }
+        catch
+        {
+            // Ignore errors during cleanup.
+        }
+    }
+
+    private static async Task<Uri?> ReadRequestUriAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        var stream = client.GetStream();
+        using var reader = new StreamReader(stream, Encoding.ASCII,
+            detectEncodingFromByteOrderMarks: false, bufferSize: HttpRequestBufferSize, leaveOpen: true);
+
+        // Parse the HTTP request line: "GET /callback?code=...&state=... HTTP/1.1"
+        var requestLine = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+        if (requestLine is null)
+            return null;
+
+        // Drain all remaining headers so the browser can receive our response.
+        // An empty line signals the end of the HTTP header section.
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { Length: > 0 })
+        {
+        }
+
+        var parts = requestLine.Split(' ');
+        if (parts.Length < 2)
+            return null;
+
+        var rawTarget = parts[1];
+        // Only origin-form targets (starting with '/') are valid for callback GETs.
+        // Absolute-form, authority-form and asterisk-form targets are rejected so they can't be
+        // concatenated into a spoofed URI.
+        if (rawTarget.Length == 0 || rawTarget[0] != '/')
+            return null;
+
+        // The authority comes from the accepted socket, never from the request's Host header: any local
+        // process can connect to the loopback port and send an arbitrary Host, which would otherwise end
+        // up as the authority of the uri handed back to the application.
+        var authority = client.Client.LocalEndPoint is IPEndPoint localEndPoint
+            ? localEndPoint.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{localEndPoint.Address}]:{localEndPoint.Port}"
+                : $"{localEndPoint.Address}:{localEndPoint.Port}"
+            : "127.0.0.1";
+
+        // Reconstruct a full URI from the request target, so downstream redirect uri handling
+        // keeps the correct host and port.
+        return Uri.TryCreate($"http://{authority}{rawTarget}", UriKind.Absolute, out var uri) ? uri : null;
+    }
+
+    private static async Task SendResponseAsync(
+        TcpClient client, BrowserResponse response, CancellationToken cancellationToken)
+    {
+        var redirect = response.ReadRedirect();
+
+        if (response.OutputStream.CanSeek)
+        {
+            response.OutputStream.Position = 0;
+        }
+
+        // A redirect carries the target in the Location header and no body.
+        var contentHeader = redirect is not null
+            ? $"Location: {redirect.AbsoluteUri}\r\n"
+            : "Content-Type: text/html; charset=utf-8\r\n";
+
+        var header =
+            $"HTTP/1.1 {(int)response.StatusCode} {GetReasonPhrase(response.StatusCode)}\r\n" +
+            contentHeader +
+            $"Content-Length: {response.OutputStream.Length}\r\n" +
+            "Connection: close\r\n\r\n";
+
+        var headerBytes = Encoding.ASCII.GetBytes(header);
+
+        var stream = client.GetStream();
+        await stream.WriteAsync(headerBytes, cancellationToken).ConfigureAwait(false);
+        if (response.OutputStream.Length > 0)
+        {
+            await response.OutputStream.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // Send FIN so the browser sees a clean end-of-stream rather than a potential RST
+        // when the TcpClient is disposed right after this method returns.
+        try
+        {
+            client.Client.Shutdown(SocketShutdown.Send);
+        }
+        catch (SocketException)
+        {
+            // Peer already closed the connection.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Client disposed during a shutdown race.
+        }
+    }
+
+    private static string GetReasonPhrase(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.OK => "OK",
+            HttpStatusCode.Found => "Found",
+            HttpStatusCode.BadRequest => "Bad Request",
+            HttpStatusCode.NotFound => "Not Found",
+            _ => statusCode.ToString() // enum name is only a best-effort reason phrase
+        };
+    }
+
+    private static BrowserResponse BuildDefaultResponse(HttpStatusCode code)
+    {
+        var stream = new MemoryStream();
+        if (code == HttpStatusCode.OK)
+        {
+            stream.Write(
+                """
+                <!doctype html>
+                <html lang="en">
+                <head>
+                    <meta charset="utf-8">
+                    <meta name="viewport" content="width=device-width,initial-scale=1">
+                    <title>Authentication complete</title>
+                </head>
+                <body style="font-family:system-ui,sans-serif;text-align:center;padding:3rem">
+                    <h1>Authentication complete</h1>
+                    <p>You can close this window and return to the application.</p>
+                </body>
+                </html>
+                """u8);
+        }
+        else
+        {
+            stream.Write(Encoding.UTF8.GetBytes($"<!doctype html><title>{GetReasonPhrase(code)}</title>"));
+        }
+
+        return new BrowserResponse(stream) { StatusCode = code };
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Authentication/LoopbackHttpListener.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/LoopbackHttpListener.cs
@@ -54,7 +54,13 @@ internal sealed class LoopbackHttpListener : IDisposable
     /// </summary>
     public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
 
+    /// <summary>
+    /// Number of requests to the redirect path that <c>callbackFilter</c> rejected.
+    /// </summary>
+    public int RejectedCallbackCount { get; private set; }
+
     public async Task<Uri> WaitForCallbackAsync(
+        Func<Uri, bool>? callbackFilter,
         Func<Uri, BrowserResponse, Task>? responseFactory,
         CancellationToken cancellationToken)
     {
@@ -73,6 +79,12 @@ internal sealed class LoopbackHttpListener : IDisposable
                     continue;
 
                 var found = requestUri.AbsolutePath == _redirectPath;
+
+                if (found && callbackFilter is not null && !callbackFilter(requestUri))
+                {
+                    found = false;
+                    RejectedCallbackCount++;
+                }
 
                 BrowserResponse? response;
                 if (found && responseFactory is not null)

--- a/src/Avalonia.Controls.WebView.Core/Authentication/SystemBrowserWebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/SystemBrowserWebAuthenticationBroker.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -28,7 +27,7 @@ internal static class SystemBrowserWebAuthenticationBroker
 
         ValidateRedirectUri(redirectUri);
 
-        using var listener = new LoopbackHttpListener(redirectUri.IsDefaultPort ? 0 : redirectUri.Port, redirectUri.AbsolutePath);
+        using var listener = new LoopbackHttpListener(redirectUri);
 
         var actualRedirectUri = new UriBuilder(redirectUri) { Port = listener.Port }.Uri;
 
@@ -121,15 +120,12 @@ internal static class SystemBrowserWebAuthenticationBroker
                 nameof(redirectUri));
         }
 
-        if (!IsLoopback(redirectUri))
+        if (!redirectUri.IsLoopback)
         {
             throw new ArgumentException(
-                $"Redirect uri host must be a loopback address when using the system browser, but was '{redirectUri.Host}'.",
+                $"Redirect uri host must be a loopback address or 'localhost' when using the system browser, but was '{redirectUri.Host}'.",
                 nameof(redirectUri));
         }
     }
-
-    private static bool IsLoopback(Uri redirectUri) =>
-        IPAddress.TryParse(redirectUri.Host, out var address) && IPAddress.IsLoopback(address);
 }
 

--- a/src/Avalonia.Controls.WebView.Core/Authentication/SystemBrowserWebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/SystemBrowserWebAuthenticationBroker.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace Avalonia.Controls.Authentication;
+
+/// <summary>
+/// Authentication flow that opens the request in the user's browser and captures the callback on a loopback HTTP listener.
+/// </summary>
+internal static class SystemBrowserWebAuthenticationBroker
+{
+    public static async Task<Uri> AuthenticateAsync(
+        Uri requestUri,
+        Uri redirectUri,
+        TimeSpan timeout,
+        Func<Uri, Task<bool>> launcher,
+        Func<Uri, BrowserResponse, Task>? responseFactory,
+        CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(
+                "The system browser authentication mode requires a local HTTP listener, which is not available in the browser.");
+        }
+
+        ValidateRedirectUri(redirectUri);
+
+        using var listener = new LoopbackHttpListener(redirectUri.IsDefaultPort ? 0 : redirectUri.Port, redirectUri.AbsolutePath);
+
+        var actualRedirectUri = new UriBuilder(redirectUri) { Port = listener.Port }.Uri;
+
+        if (actualRedirectUri != redirectUri)
+        {
+            // Coerce requestUri parameter
+            requestUri = ReplaceRedirectUri(requestUri, actualRedirectUri);
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        // Start accepting before the browser is launched. The callback can arrive as soon as the
+        // browser opens, and a launcher is not required to return before that happens.
+        var callbackTask = listener.WaitForCallbackAsync(responseFactory, linkedCts.Token);
+
+        try
+        {
+            var success = false;
+            Exception? error = null;
+            try
+            {
+                success = await launcher(requestUri).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                error = ex;   
+            }
+
+            if (!success || error != null)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to open '{requestUri}' in the system browser.", error);
+            }
+
+            return await callbackTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested &&
+                                                 !cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(
+                $"Timed out after {timeout} waiting for the authentication callback.");
+        }
+        finally
+        {
+            if (!callbackTask.IsCompleted)
+            {
+                await linkedCts.CancelAsync().ConfigureAwait(false);
+                _ = callbackTask.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+            }
+        }
+    }
+
+    private static Uri ReplaceRedirectUri(Uri requestUri, Uri redirectUri)
+    {
+        var builder = new UriBuilder(requestUri);
+
+        var query = HttpUtility.ParseQueryString(requestUri.Query);
+
+        if (query.GetValues("redirect_uri") is not { Length: 1 })
+        {
+            throw new InvalidOperationException(
+                "The request URI must contain exactly one 'redirect_uri' query parameter.");
+        }
+
+        query["redirect_uri"] = redirectUri.AbsoluteUri;
+
+        builder.Query = query.ToString();
+
+        return builder.Uri;
+    }
+
+    private static void ValidateRedirectUri(Uri redirectUri)
+    {
+        if (!redirectUri.IsAbsoluteUri)
+        {
+            throw new ArgumentException(
+                "Redirect uri must be absolute when using the system browser.", nameof(redirectUri));
+        }
+
+        if (redirectUri.Scheme != Uri.UriSchemeHttp)
+        {
+            throw new ArgumentException(
+                $"Redirect uri must use the '{Uri.UriSchemeHttp}' scheme when using the system browser, but was '{redirectUri.Scheme}'.",
+                nameof(redirectUri));
+        }
+
+        if (!IsLoopback(redirectUri))
+        {
+            throw new ArgumentException(
+                $"Redirect uri host must be a loopback address when using the system browser, but was '{redirectUri.Host}'.",
+                nameof(redirectUri));
+        }
+    }
+
+    private static bool IsLoopback(Uri redirectUri) =>
+        IPAddress.TryParse(redirectUri.Host, out var address) && IPAddress.IsLoopback(address);
+}
+

--- a/src/Avalonia.Controls.WebView.Core/Authentication/SystemBrowserWebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView.Core/Authentication/SystemBrowserWebAuthenticationBroker.cs
@@ -16,6 +16,7 @@ internal static class SystemBrowserWebAuthenticationBroker
         Uri redirectUri,
         TimeSpan timeout,
         Func<Uri, Task<bool>> launcher,
+        Func<Uri, bool>? callbackFilter,
         Func<Uri, BrowserResponse, Task>? responseFactory,
         CancellationToken cancellationToken)
     {
@@ -42,7 +43,7 @@ internal static class SystemBrowserWebAuthenticationBroker
 
         // Start accepting before the browser is launched. The callback can arrive as soon as the
         // browser opens, and a launcher is not required to return before that happens.
-        var callbackTask = listener.WaitForCallbackAsync(responseFactory, linkedCts.Token);
+        var callbackTask = listener.WaitForCallbackAsync(callbackFilter, responseFactory, linkedCts.Token);
 
         try
         {
@@ -68,8 +69,13 @@ internal static class SystemBrowserWebAuthenticationBroker
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested &&
                                                  !cancellationToken.IsCancellationRequested)
         {
+            // A filter that never matches otherwise presents as a silent wait until the timeout.
+            var rejected = listener.RejectedCallbackCount > 0
+                ? $" {listener.RejectedCallbackCount} callback(s) were rejected by the callback filter."
+                : "";
+
             throw new OperationCanceledException(
-                $"Timed out after {timeout} waiting for the authentication callback.");
+                $"Timed out after {timeout} waiting for the authentication callback.{rejected}");
         }
         finally
         {

--- a/src/Avalonia.Controls.WebView.Core/WebViewHelper.cs
+++ b/src/Avalonia.Controls.WebView.Core/WebViewHelper.cs
@@ -13,7 +13,7 @@ internal static class WebViewHelper
         BuildInvokeCSharpActionScript("window.webkit.messageHandlers." + messageName, stringify: stringify);
 
     /// <param name="postObject">Target object to send message to.</param>
-    /// <param name="postMethod">Method on the <see cref="postObject"/> that should be invoked to pass the message.</param>
+    /// <param name="postMethod">Method on the <paramref name="postObject"/> that should be invoked to pass the message.</param>
     /// <param name="stringify">
     /// Defines if post data should be JSON serialized,
     /// some backends do that automatically when marshall objects to the C# handlers.

--- a/src/Avalonia.Controls.WebView/Avalonia.Controls.WebView.csproj
+++ b/src/Avalonia.Controls.WebView/Avalonia.Controls.WebView.csproj
@@ -11,6 +11,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
+    <DefineConstants>$(DefineConstants);BROWSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Avalonia.Controls.WebView.Core\Avalonia.Controls.WebView.Core.csproj" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Avalonia.Controls.WebView/README.md
+++ b/src/Avalonia.Controls.WebView/README.md
@@ -39,5 +39,6 @@ Native web dialog that provides a way to display web content in a separate windo
 ### WebAuthenticationBroker
 
 WebAuthenticationBroker is a utility class that facilitates OAuth and other web-based authentication flows by providing a secure way to handle web authentication in desktop applications.
+Set `WebAuthenticatorMode.Browser` to run the flow in the user's default browser and capture the callback on a local loopback HTTP listener, which is required by providers that reject embedded webviews.
 
 **Documentation**: https://docs.avaloniaui.net/accelerate/components/webview/webauthenticationbroker

--- a/src/Avalonia.Controls.WebView/README.md
+++ b/src/Avalonia.Controls.WebView/README.md
@@ -41,4 +41,6 @@ Native web dialog that provides a way to display web content in a separate windo
 WebAuthenticationBroker is a utility class that facilitates OAuth and other web-based authentication flows by providing a secure way to handle web authentication in desktop applications.
 Set `WebAuthenticatorMode.Browser` to run the flow in the user's default browser and capture the callback on a local loopback HTTP listener, which is required by providers that reject embedded webviews.
 
+That listener accepts connections from any process on the machine, so the returned `CallbackUri` is untrusted input: validate its `code`, `state` and `error` parameters, and use PKCE.
+
 **Documentation**: https://docs.avaloniaui.net/accelerate/components/webview/webauthenticationbroker

--- a/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
@@ -124,7 +124,7 @@ namespace Avalonia.Xpf.Controls
                 browserOptions.Timeout,
                 uri => topLevel.Launcher.LaunchUriAsync(uri),
                 browserOptions.CallbackFilter is { } filter ?
-                    uri => filter.Invoke(uri) :
+                    uri => filter.Invoke(new WebAuthenticationResult(uri)) :
                     null,
                 browserOptions.ResponseHandler is not null ?
                     (uri, response) => browserOptions

--- a/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Controls.Authentication;
 using Avalonia.Platform;
 using Core = Avalonia.Controls;
 #if WPF
 using AvaloniaUI.Xpf.WpfAbstractions;
 using Avalonia.Controls;
+using AvTopLevel = Avalonia.Controls.TopLevel;
 #elif AVALONIA
 using AvTopLevel = Avalonia.Controls.TopLevel;
 #endif
@@ -24,7 +27,7 @@ namespace Avalonia.Xpf.Controls
         /// Starts an authentication flow by navigating to the specified start URI and monitoring for navigation to the end URI.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">Platform is not supported.</exception>
-        /// <exception cref="OperationCanceledException">Operation was cancelled programmatically or by user.</exception>
+        /// <exception cref="OperationCanceledException">Operation was canceled programmatically or by user.</exception>
         public static async Task<WebAuthenticationResult> AuthenticateAsync
 #if WPF
             (System.Windows.Window topLevel, WebAuthenticatorOptions options)
@@ -32,47 +35,101 @@ namespace Avalonia.Xpf.Controls
             (AvTopLevel topLevel, WebAuthenticatorOptions options)
 #endif
         {
-            var supportsNativeWebDialog =
-                OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() ||
-                OperatingSystem.IsAndroid();
+            var mode = GetEffectiveMode(options);
 
-            if (!(supportsNativeWebDialog & options.PreferNativeWebDialog)
 #if WPF
-                && XpfWpfAbstraction.GetAvaloniaTopLevelForWindow(topLevel) is { } avTopLevel
+            var avTopLevel = XpfWpfAbstraction.GetAvaloniaTopLevelForWindow(topLevel);
 #elif AVALONIA
-                && topLevel is var avTopLevel
+            var avTopLevel = topLevel;
 #endif
-                )
+
+            if (avTopLevel is null)
             {
+                throw new ArgumentNullException(nameof(topLevel));
+            }
+
+            switch (mode)
+            {
+#pragma warning disable CA1416
+                case WebAuthenticatorMode.Browser:
+                    return await AuthenticateSystemBrowserAsync(avTopLevel, options);
 #if ANDROID
-                if (OperatingSystem.IsAndroid())
+                case WebAuthenticatorMode.System when OperatingSystem.IsAndroid():
                 {
                     var uri = await Core.Android.AndroidWebAuthenticationBroker.AuthenticateAsync(avTopLevel,
                         options.RequestUri, options.RedirectUri);
                     return new WebAuthenticationResult(uri);
                 }
 #else
-                if ((OperatingSystem.IsIOSVersionAtLeast(13, 0) || OperatingSystem.IsMacOSVersionAtLeast(10, 15)))
+                case WebAuthenticatorMode.System when (OperatingSystem.IsIOSVersionAtLeast(13, 0) || OperatingSystem.IsMacOSVersionAtLeast(10, 15)):
                 {
                     var uri = await Core.Macios.MaciosWebAuthenticationBroker.AuthenticateAsync(avTopLevel,
                         options.RequestUri, options.RedirectUri.Scheme, options.NonPersistent);
                     return new WebAuthenticationResult(uri);
                 }
-                else if (OperatingSystem.IsBrowser())
+                case WebAuthenticatorMode.System when OperatingSystem.IsBrowser():
                 {
                     var uri = await Core.Browser.BrowserWebAuthenticationBroker.AuthenticateAsync(avTopLevel,
                         options.RequestUri, options.RedirectUri);
                     return new WebAuthenticationResult(uri);
                 }
 #endif
+                case WebAuthenticatorMode.NativeWebDialog:
+                    return await AuthenticateDialogAsync(topLevel, options);
+                default:
+                    throw new PlatformNotSupportedException();
+#pragma warning restore CA1416
             }
+        }
 
-            if (supportsNativeWebDialog)
+        private static WebAuthenticatorMode GetEffectiveMode(WebAuthenticatorOptions options)
+        {
+#pragma warning disable CA1416
+#pragma warning disable CS0618
+            var supportsNativeWebDialog = OperatingSystem.IsWindows() || OperatingSystem.IsLinux() ||
+                                          OperatingSystem.IsMacOS() || OperatingSystem.IsAndroid();
+            var supportsSystem = OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() ||
+                                 OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser();
+            var supportsBrowserLauncher = !OperatingSystem.IsBrowser(); // can't launch browser from the browser, duh.
+
+            var mode = options is { Mode: WebAuthenticatorMode.Auto, PreferNativeWebDialog: true } ?
+                WebAuthenticatorMode.NativeWebDialog :
+                options.Mode;
+
+            return mode switch
             {
-                return await AuthenticateDialogAsync(topLevel, options);
-            }
+                WebAuthenticatorMode.Auto when supportsSystem => WebAuthenticatorMode.System,
+                WebAuthenticatorMode.Auto when supportsNativeWebDialog => WebAuthenticatorMode.NativeWebDialog,
+                WebAuthenticatorMode.Auto when supportsBrowserLauncher => WebAuthenticatorMode.Browser,
 
-            throw new PlatformNotSupportedException();
+                WebAuthenticatorMode.System when supportsSystem => WebAuthenticatorMode.System,
+                WebAuthenticatorMode.NativeWebDialog when supportsNativeWebDialog => WebAuthenticatorMode.NativeWebDialog,
+                WebAuthenticatorMode.Browser when supportsBrowserLauncher => WebAuthenticatorMode.Browser,
+
+                _ => throw new PlatformNotSupportedException(
+                    $"WebAuthenticatorMode.{mode} is not supported on the current platform")
+            };
+#pragma warning restore CS0618
+#pragma warning restore CA1416
+        }
+
+        private static async Task<WebAuthenticationResult> AuthenticateSystemBrowserAsync(
+            AvTopLevel topLevel, WebAuthenticatorOptions options)
+        {
+            var browserOptions = options.BrowserOptions ?? new BrowserOptions();
+
+            var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                options.RequestUri,
+                options.RedirectUri,
+                browserOptions.Timeout,
+                uri => topLevel.Launcher.LaunchUriAsync(uri),
+                browserOptions.ResponseHandler is not null ?
+                    (uri, response) => browserOptions
+                        .ResponseHandler.Invoke(new WebAuthenticationResult(uri), response) :
+                    null,
+                CancellationToken.None);
+
+            return new WebAuthenticationResult(callbackUri);
         }
 
         private static async Task<WebAuthenticationResult> AuthenticateDialogAsync
@@ -150,29 +207,6 @@ namespace Avalonia.Xpf.Controls
             dialog.Resize(600, 700);
             return dialog;
         }
-    }
-
-    /// <summary>
-    /// Authentication options that control the broker's behavior.
-    /// </summary>
-    /// <param name="RequestUri">The initial URI that starts the authentication flow.</param>
-    /// <param name="RedirectUri">URI that indicates the completion of the authentication flow.</param>
-    public record WebAuthenticatorOptions(Uri RequestUri, Uri RedirectUri)
-    {
-        /// <summary>
-        /// If true, WebAuthenticationBroker will avoid platform specific implementation option, and will use webview dialog window.
-        /// </summary>
-        public bool PreferNativeWebDialog { get; init; }
-
-        /// <summary>
-        /// Hint for the platform implementation to not store any session data persistently.
-        /// </summary>
-        public bool NonPersistent { get; init; }
-
-        /// <summary>
-        /// Callback that can be used to override NativeWebDialog creation when WebAuthenticationBroker uses dialog implementation instead of system auth APIs.
-        /// </summary>
-        public Func<NativeWebDialog?>? NativeWebDialogFactory { get; init; }
     }
 
     /// <param name="CallbackUri">The response URI containing authentication data.</param>

--- a/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
@@ -123,6 +123,9 @@ namespace Avalonia.Xpf.Controls
                 options.RedirectUri,
                 browserOptions.Timeout,
                 uri => topLevel.Launcher.LaunchUriAsync(uri),
+                browserOptions.CallbackFilter is { } filter ?
+                    uri => filter.Invoke(uri) :
+                    null,
                 browserOptions.ResponseHandler is not null ?
                     (uri, response) => browserOptions
                         .ResponseHandler.Invoke(new WebAuthenticationResult(uri), response) :

--- a/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
@@ -147,12 +147,13 @@ public record BrowserOptions
     /// <summary>
     /// Decides whether a request received on the redirect path belongs to the authentication flow.
     /// </summary>
-    /// <param name="callbackUri">
-    /// The candidate callback uri.
+    /// <param name="result">
+    /// The candidate result.
+    /// Its <see cref="WebAuthenticationResult.CallbackUri"/> is unvalidated input that any local process can produce.
     /// </param>
     /// <returns>
-    /// <see langword="true"/> to complete the flow with <paramref name="callbackUri"/>;
+    /// <see langword="true"/> to complete the flow with <paramref name="result"/>;
     /// <see langword="false"/> to reject it and keep waiting.
     /// </returns>
-    public delegate bool BrowserCallbackFilter(Uri callbackUri);
+    public delegate bool BrowserCallbackFilter(WebAuthenticationResult result);
 }

--- a/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
@@ -78,7 +78,19 @@ public enum WebAuthenticatorMode
     /// Opens the authentication flow in the user's default web browser and uses a local HTTP listener to receive the redirect.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Requires <see cref="WebAuthenticatorOptions.RedirectUri"/> to be an <c>http</c> loopback address.
+    /// </para>
+    /// <para>
+    /// The redirect is received on a local socket.
+    /// Any process on the machine can connect to it, so <see cref="WebAuthenticationResult.CallbackUri"/> is untrusted input.
+    /// The caller must validate its <c>code</c>, <c>state</c> and <c>error</c> parameters.
+    /// </para>
+    /// <para>
+    /// PKCE is strongly recommended (RFC 8252, section 8.1).
+    /// It is what makes an injected authorization code unusable at the token endpoint.
+    /// Use <see cref="BrowserOptions.CallbackFilter"/> to keep the listener waiting when a request does not belong to the flow.
+    /// </para>
     /// </remarks>
     [UnsupportedOSPlatform("browser")]
     Browser
@@ -104,6 +116,21 @@ public record BrowserOptions
     public BrowserResponseHandler? ResponseHandler { get; init; }
 
     /// <summary>
+    /// Gets or sets a callback that decides whether a request to the redirect path belongs to this authentication flow.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The local listener accepts connections from any process on the machine.
+    /// A request that reaches the redirect path is therefore not necessarily the browser's.
+    /// </para>
+    /// <para>
+    /// The usual implementation compares the <c>state</c> query parameter against the value sent in the authorization request.
+    /// The caller still has to check <c>code</c>, <c>state</c> and <c>error</c> on the returned <see cref="WebAuthenticationResult.CallbackUri"/>.
+    /// </para>
+    /// </remarks>
+    public BrowserCallbackFilter? CallbackFilter { get; init; }
+
+    /// <summary>
     /// Handles the HTTP response sent to the browser after the authentication callback
     /// is received.
     /// </summary>
@@ -116,4 +143,16 @@ public record BrowserOptions
     public delegate Task BrowserResponseHandler(
         WebAuthenticationResult result,
         BrowserResponse response);
+
+    /// <summary>
+    /// Decides whether a request received on the redirect path belongs to the authentication flow.
+    /// </summary>
+    /// <param name="callbackUri">
+    /// The candidate callback uri.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> to complete the flow with <paramref name="callbackUri"/>;
+    /// <see langword="false"/> to reject it and keep waiting.
+    /// </returns>
+    public delegate bool BrowserCallbackFilter(Uri callbackUri);
 }

--- a/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Avalonia.Controls.Authentication;
+
+#if AVALONIA
+namespace Avalonia.Controls;
+#elif WPF
+namespace Avalonia.Xpf.Controls;
+#endif
+
+/// <summary>
+/// Authentication options that control the broker's behavior.
+/// </summary>
+/// <param name="RequestUri">The initial URI that starts the authentication flow.</param>
+/// <param name="RedirectUri">URI that indicates the completion of the authentication flow.</param>
+public record WebAuthenticatorOptions(Uri RequestUri, Uri RedirectUri)
+{
+    /// <summary>
+    /// Implementation used to run the flow.
+    /// </summary>
+    public WebAuthenticatorMode Mode { get; init; }
+
+    /// <summary>
+    /// If true, WebAuthenticationBroker will avoid platform specific implementation option, and will use webview dialog window.
+    /// </summary>
+    [Obsolete("Use Mode = WebAuthenticatorMode.NativeWebDialog instead.")]
+    public bool PreferNativeWebDialog { get; init; }
+
+    /// <summary>
+    /// Hint for the platform implementation to not store any session data persistently.
+    /// </summary>
+    /// <remarks>
+    /// Ignored by <see cref="WebAuthenticatorMode.Browser"/>, which uses the user's own browser session.
+    /// </remarks>
+    public bool NonPersistent { get; init; }
+
+    /// <summary>
+    /// Callback that can be used to override NativeWebDialog creation when WebAuthenticationBroker uses dialog implementation instead of system auth APIs.
+    /// </summary>
+    public Func<NativeWebDialog?>? NativeWebDialogFactory { get; init; }
+
+    /// <summary>
+    /// Options used when <see cref="Mode"/> is <see cref="WebAuthenticatorMode.Browser"/>.
+    /// </summary>
+    public BrowserOptions? BrowserOptions { get; init; }
+}
+
+/// <summary>
+/// Selects which implementation <see cref="WebAuthenticationBroker"/> uses to run the flow.
+/// </summary>
+public enum WebAuthenticatorMode
+{
+    /// <summary>
+    /// Automatically selects the most appropriate authentication mode for the current platform.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Uses the platform's native web authentication APIs when available.
+    /// </summary>
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("ios")]
+    [SupportedOSPlatform("android")]
+    [SupportedOSPlatform("browser")]
+    System,
+
+    /// <summary>
+    /// Displays the authentication flow in a <see cref="NativeWebDialog"/> containing an embedded web view.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("android")]
+    [SupportedOSPlatform("linux")]
+    NativeWebDialog,
+
+    /// <summary>
+    /// Opens the authentication flow in the user's default web browser and uses a local HTTP listener to receive the redirect.
+    /// </summary>
+    /// <remarks>
+    /// Requires <see cref="WebAuthenticatorOptions.RedirectUri"/> to be an <c>http</c> loopback address.
+    /// </remarks>
+    [UnsupportedOSPlatform("browser")]
+    Browser
+}
+
+/// <summary>
+/// Options for <see cref="WebAuthenticatorMode.Browser"/>.
+/// </summary>
+public record BrowserOptions
+{
+    /// <summary>
+    /// How long to wait for the callback before the flow is canceled.
+    /// Defaults to 5 minutes.
+    /// </summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Gets or sets a callback used to customize the HTTP response sent to the browser after the authentication callback is received.
+    /// </summary>
+    /// <remarks>
+    /// If not specified, a default response is sent to the browser.
+    /// </remarks>
+    public BrowserResponseHandler? ResponseHandler { get; init; }
+
+    /// <summary>
+    /// Handles the HTTP response sent to the browser after the authentication callback
+    /// is received.
+    /// </summary>
+    /// <param name="result">
+    /// The result of the authentication flow.
+    /// </param>
+    /// <param name="response">
+    /// The response used to configure the HTTP response sent to the browser.
+    /// </param>
+    public delegate Task BrowserResponseHandler(
+        WebAuthenticationResult result,
+        BrowserResponse response);
+}

--- a/src/Avalonia.Xpf.Controls.WebView/Avalonia.Xpf.Controls.WebView.csproj
+++ b/src/Avalonia.Xpf.Controls.WebView/Avalonia.Xpf.Controls.WebView.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\Avalonia.Controls.WebView\WebAuthenticationBroker.cs">
       <Link>WebAuthenticationBroker.cs</Link>
     </Compile>
+    <Compile Include="..\Avalonia.Controls.WebView\WebAuthenticatorOptions.cs">
+      <Link>WebAuthenticatorOptions.cs</Link>
+    </Compile>
     <Compile Include="..\Avalonia.Controls.WebView\WindowNativeWebViewDialog.cs">
       <Link>WindowNativeWebViewDialog.cs</Link>
     </Compile>

--- a/src/Avalonia.Xpf.Controls.WebView/README.md
+++ b/src/Avalonia.Xpf.Controls.WebView/README.md
@@ -46,4 +46,6 @@ Native web dialog that provides a way to display web content in a separate windo
 WebAuthenticationBroker is a utility class that facilitates OAuth and other web-based authentication flows by providing a secure way to handle web authentication in desktop applications.
 Set `WebAuthenticatorMode.Browser` to run the flow in the user's default browser and capture the callback on a local loopback HTTP listener, which is required by providers that reject embedded webviews.
 
+That listener accepts connections from any process on the machine, so the returned `CallbackUri` is untrusted input: validate its `code`, `state` and `error` parameters, and use PKCE.
+
 **Documentation**: https://docs.avaloniaui.net/accelerate/components/webview/webauthenticationbroker

--- a/src/Avalonia.Xpf.Controls.WebView/README.md
+++ b/src/Avalonia.Xpf.Controls.WebView/README.md
@@ -44,5 +44,6 @@ Native web dialog that provides a way to display web content in a separate windo
 ### WebAuthenticationBroker
 
 WebAuthenticationBroker is a utility class that facilitates OAuth and other web-based authentication flows by providing a secure way to handle web authentication in desktop applications.
+Set `WebAuthenticatorMode.Browser` to run the flow in the user's default browser and capture the callback on a local loopback HTTP listener, which is required by providers that reject embedded webviews.
 
 **Documentation**: https://docs.avaloniaui.net/accelerate/components/webview/webauthenticationbroker

--- a/tests/Avalonia.Controls.WebView.Tests/LoopbackHttpListenerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/LoopbackHttpListenerTests.cs
@@ -33,7 +33,7 @@ public class LoopbackHttpListenerTests
     [Fact]
     public async Task Should_Return_Uri_With_Query_For_Matching_Path()
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
@@ -50,10 +50,52 @@ public class LoopbackHttpListenerTests
         Assert.Equal(listener.Port, uri.Port);
     }
 
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    public async Task Should_Report_The_Configured_Host_In_The_Callback_Uri(string host)
+    {
+        // A redirect uri written as "localhost" must come back as "localhost": the token exchange has to
+        // present the same redirect_uri string that the authorization request carried.
+        using var listener = new LoopbackHttpListener(new Uri($"http://{host}{RedirectPath}"));
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal(host, uri.Host);
+        Assert.Equal(listener.Port, uri.Port);
+    }
+
+    [Fact]
+    public async Task Should_Bind_IPv6_Loopback_For_An_IPv6_Redirect_Uri()
+    {
+        Assert.SkipUnless(Socket.OSSupportsIPv6, "The machine has no IPv6 stack.");
+
+        using var listener = new LoopbackHttpListener(new Uri($"http://[::1]{RedirectPath}"));
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://[::1]:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal("[::1]", uri.Host);
+        Assert.Equal(listener.Port, uri.Port);
+    }
+
     [Fact]
     public async Task Should_Allocate_A_Free_Port_When_Zero_Is_Requested()
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
 
         Assert.NotEqual(0, listener.Port);
 
@@ -66,7 +108,7 @@ public class LoopbackHttpListenerTests
     [Fact]
     public async Task Should_Send_A_Default_Success_Page_When_No_Handler_Is_Provided()
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(null, null, cts.Token);
@@ -87,7 +129,7 @@ public class LoopbackHttpListenerTests
     {
         var handlerCalls = 0;
 
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
@@ -123,7 +165,7 @@ public class LoopbackHttpListenerTests
     [Fact]
     public async Task Should_Send_Html_Body_From_Response_Handler()
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(null, Html("<html>custom body</html>"), cts.Token);
@@ -144,7 +186,7 @@ public class LoopbackHttpListenerTests
     {
         Uri? handlerUri = null;
 
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
@@ -171,7 +213,7 @@ public class LoopbackHttpListenerTests
     {
         var location = new Uri("https://example.com/signed-in");
 
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
@@ -201,7 +243,7 @@ public class LoopbackHttpListenerTests
     [Fact]
     public async Task Should_Ignore_Absolute_Form_Request_Target()
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
@@ -230,7 +272,7 @@ public class LoopbackHttpListenerTests
     [InlineData("127.0.0.1:1")]
     public async Task Should_Ignore_The_Host_Header(string host)
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
@@ -249,11 +291,46 @@ public class LoopbackHttpListenerTests
     }
 
     [Fact]
+    public async Task Should_Reject_An_Invalid_Redirect_Uri()
+    {
+        Exception? nullException = null;
+        Exception? relativeException = null;
+
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(
+            null,
+            (_, response) =>
+            {
+                nullException = Record.Exception(() => response.Redirect(null!));
+                relativeException = Record.Exception(() => response.Redirect(new Uri("/x", UriKind.Relative)));
+
+                // A rejected redirect must leave the response untouched.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                return WriteAsync(response, "<html>ok</html>");
+            },
+            cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("<html>ok</html>", await response.Content.ReadAsStringAsync(cts.Token));
+
+        await waitTask;
+
+        _ = Assert.IsType<ArgumentNullException>(nullException);
+        Assert.Equal("uri", Assert.IsType<ArgumentException>(relativeException).ParamName);
+    }
+
+    [Fact]
     public async Task Should_Reject_A_Filtered_Callback_And_Keep_Listening()
     {
         var handlerCalls = 0;
 
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
@@ -291,7 +368,7 @@ public class LoopbackHttpListenerTests
     {
         var expected = new InvalidOperationException("bad filter");
 
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(_ => throw expected, null, cts.Token);
@@ -308,7 +385,7 @@ public class LoopbackHttpListenerTests
     [Fact]
     public async Task Should_Respect_Cancellation()
     {
-        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
         using var cts = new CancellationTokenSource();
 
         var waitTask = listener.WaitForCallbackAsync(null, null, cts.Token);
@@ -321,10 +398,10 @@ public class LoopbackHttpListenerTests
     [Fact]
     public void Should_Fail_When_The_Port_Is_Already_In_Use()
     {
-        using var first = new LoopbackHttpListener(0, RedirectPath);
+        using var first = new LoopbackHttpListener(new Uri($"http://127.0.0.1{RedirectPath}"));
 
         _ = Assert.Throws<InvalidOperationException>(
-            () => new LoopbackHttpListener(first.Port, RedirectPath));
+            () => new LoopbackHttpListener(new Uri($"http://127.0.0.1:{first.Port}{RedirectPath}")));
     }
 
     private static async Task SendRawRequestAsync(int port, string request, CancellationToken cancellationToken)

--- a/tests/Avalonia.Controls.WebView.Tests/LoopbackHttpListenerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/LoopbackHttpListenerTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls.Authentication;
+using Xunit;
+
+namespace Avalonia.Controls.WebView.Tests;
+
+public class LoopbackHttpListenerTests
+{
+    private const string RedirectPath = "/callback";
+
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(30);
+
+    private static Func<Uri, BrowserResponse, Task> Html(string body) =>
+        (_, response) =>
+        {
+            response.StatusCode = HttpStatusCode.OK;
+            return WriteAsync(response, body);
+        };
+
+    private static async Task WriteAsync(BrowserResponse response, string body)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        await response.OutputStream.WriteAsync(bytes);
+    }
+
+    [Fact]
+    public async Task Should_Return_Uri_With_Query_For_Matching_Path()
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(Html("<html>ok</html>"), cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc&state=xyz", cts.Token);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal(RedirectPath, uri.AbsolutePath);
+        Assert.Equal("?code=abc&state=xyz", uri.Query);
+        Assert.Equal(listener.Port, uri.Port);
+    }
+
+    [Fact]
+    public async Task Should_Allocate_A_Free_Port_When_Zero_Is_Requested()
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+
+        Assert.NotEqual(0, listener.Port);
+
+        // The allocated port must be the one actually accepting connections.
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, listener.Port, TestContext.Current.CancellationToken);
+        Assert.True(client.Connected);
+    }
+
+    [Fact]
+    public async Task Should_Send_A_Default_Success_Page_When_No_Handler_Is_Provided()
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(null, cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("Authentication complete", await response.Content.ReadAsStringAsync(cts.Token));
+
+        await waitTask;
+    }
+
+    [Fact]
+    public async Task Should_Reply_404_For_Non_Matching_Path_And_Keep_Listening()
+    {
+        var handlerCalls = 0;
+
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(
+            (_, response) =>
+            {
+                Interlocked.Increment(ref handlerCalls);
+                return WriteAsync(response, "<html>ok</html>");
+            },
+            cts.Token);
+
+        using var http = new HttpClient();
+
+        // Favicon prefetch: should receive 404, listener keeps running.
+        using var faviconResponse = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}/favicon.ico", cts.Token);
+        Assert.Equal(HttpStatusCode.NotFound, faviconResponse.StatusCode);
+        Assert.False(waitTask.IsCompleted, "Listener should keep running after 404.");
+
+        // The user's handler must not observe requests that are not the callback.
+        Assert.Equal(0, Volatile.Read(ref handlerCalls));
+
+        // Actual callback follows.
+        using var callbackResponse = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+        Assert.Equal(HttpStatusCode.OK, callbackResponse.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal(RedirectPath, uri.AbsolutePath);
+        Assert.Equal(1, Volatile.Read(ref handlerCalls));
+    }
+
+    [Fact]
+    public async Task Should_Send_Html_Body_From_Response_Handler()
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(Html("<html>custom body</html>"), cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+
+        Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("utf-8", response.Content.Headers.ContentType?.CharSet);
+        Assert.Equal("<html>custom body</html>", await response.Content.ReadAsStringAsync(cts.Token));
+
+        await waitTask;
+    }
+
+    [Fact]
+    public async Task Should_Pass_The_Callback_Uri_To_The_Response_Handler()
+    {
+        Uri? handlerUri = null;
+
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(
+            (uri, response) =>
+            {
+                handlerUri = uri;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                return Task.CompletedTask;
+            },
+            cts.Token);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal(uri, handlerUri);
+    }
+
+    [Fact]
+    public async Task Should_Send_Redirect_When_Response_Is_Configured_To_Redirect()
+    {
+        var location = new Uri("https://example.com/signed-in");
+
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(
+            (_, response) =>
+            {
+                response.Redirect(location);
+
+                // Redirecting must select the status code on its own.
+                Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+                return Task.CompletedTask;
+            },
+            cts.Token);
+
+        using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+        using var http = new HttpClient(handler);
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=abc", cts.Token);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal(location, response.Headers.Location);
+        Assert.Empty(await response.Content.ReadAsStringAsync(cts.Token));
+
+        await waitTask;
+    }
+
+    [Fact]
+    public async Task Should_Ignore_Absolute_Form_Request_Target()
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(Html("<html>ok</html>"), cts.Token);
+
+        // An absolute-form target must not be concatenated into a spoofed callback uri.
+        await SendRawRequestAsync(listener.Port,
+            $"GET http://evil.com{RedirectPath}?code=abc HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+            cts.Token);
+
+        Assert.False(waitTask.IsCompleted, "Absolute-form target should not complete the flow.");
+
+        // A well formed request still completes it.
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=real", cts.Token);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal("127.0.0.1", uri.Host);
+        Assert.Equal("?code=real", uri.Query);
+    }
+
+    [Theory]
+    [InlineData("evil.example")]
+    [InlineData("user@evil.example")]
+    [InlineData("127.0.0.1:1")]
+    public async Task Should_Ignore_The_Host_Header(string host)
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(Html("<html>ok</html>"), cts.Token);
+
+        // Any local process can connect to the port and claim any authority it likes; the callback
+        // uri handed to the application must describe the socket the request actually arrived on.
+        await SendRawRequestAsync(listener.Port,
+            $"GET {RedirectPath}?code=abc HTTP/1.1\r\nHost: {host}\r\n\r\n",
+            cts.Token);
+
+        var uri = await waitTask;
+        Assert.Equal("127.0.0.1", uri.Host);
+        Assert.Equal(listener.Port, uri.Port);
+        Assert.Empty(uri.UserInfo);
+        Assert.Equal("?code=abc", uri.Query);
+    }
+
+    [Fact]
+    public async Task Should_Respect_Cancellation()
+    {
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = listener.WaitForCallbackAsync(null, cts.Token);
+
+        await cts.CancelAsync();
+
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitTask);
+    }
+
+    [Fact]
+    public void Should_Fail_When_The_Port_Is_Already_In_Use()
+    {
+        using var first = new LoopbackHttpListener(0, RedirectPath);
+
+        _ = Assert.Throws<InvalidOperationException>(
+            () => new LoopbackHttpListener(first.Port, RedirectPath));
+    }
+
+    private static async Task SendRawRequestAsync(int port, string request, CancellationToken cancellationToken)
+    {
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port, cancellationToken);
+
+        var stream = client.GetStream();
+        var bytes = Encoding.ASCII.GetBytes(request);
+        await stream.WriteAsync(bytes, cancellationToken);
+        await stream.FlushAsync(cancellationToken);
+
+        // Read until the listener closes the connection, so the request is fully processed
+        // before the assertions run.
+        using var drain = new MemoryStream();
+        await stream.CopyToAsync(drain, cancellationToken);
+    }
+}

--- a/tests/Avalonia.Controls.WebView.Tests/LoopbackHttpListenerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/LoopbackHttpListenerTests.cs
@@ -36,7 +36,7 @@ public class LoopbackHttpListenerTests
         using var listener = new LoopbackHttpListener(0, RedirectPath);
         using var cts = new CancellationTokenSource(s_timeout);
 
-        var waitTask = listener.WaitForCallbackAsync(Html("<html>ok</html>"), cts.Token);
+        var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
 
         using var http = new HttpClient();
         using var response = await http.GetAsync(
@@ -69,7 +69,7 @@ public class LoopbackHttpListenerTests
         using var listener = new LoopbackHttpListener(0, RedirectPath);
         using var cts = new CancellationTokenSource(s_timeout);
 
-        var waitTask = listener.WaitForCallbackAsync(null, cts.Token);
+        var waitTask = listener.WaitForCallbackAsync(null, null, cts.Token);
 
         using var http = new HttpClient();
         using var response = await http.GetAsync(
@@ -91,6 +91,7 @@ public class LoopbackHttpListenerTests
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
+            null,
             (_, response) =>
             {
                 Interlocked.Increment(ref handlerCalls);
@@ -125,7 +126,7 @@ public class LoopbackHttpListenerTests
         using var listener = new LoopbackHttpListener(0, RedirectPath);
         using var cts = new CancellationTokenSource(s_timeout);
 
-        var waitTask = listener.WaitForCallbackAsync(Html("<html>custom body</html>"), cts.Token);
+        var waitTask = listener.WaitForCallbackAsync(null, Html("<html>custom body</html>"), cts.Token);
 
         using var http = new HttpClient();
         using var response = await http.GetAsync(
@@ -147,6 +148,7 @@ public class LoopbackHttpListenerTests
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
+            null,
             (uri, response) =>
             {
                 handlerUri = uri;
@@ -173,6 +175,7 @@ public class LoopbackHttpListenerTests
         using var cts = new CancellationTokenSource(s_timeout);
 
         var waitTask = listener.WaitForCallbackAsync(
+            null,
             (_, response) =>
             {
                 response.Redirect(location);
@@ -201,7 +204,7 @@ public class LoopbackHttpListenerTests
         using var listener = new LoopbackHttpListener(0, RedirectPath);
         using var cts = new CancellationTokenSource(s_timeout);
 
-        var waitTask = listener.WaitForCallbackAsync(Html("<html>ok</html>"), cts.Token);
+        var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
 
         // An absolute-form target must not be concatenated into a spoofed callback uri.
         await SendRawRequestAsync(listener.Port,
@@ -230,7 +233,7 @@ public class LoopbackHttpListenerTests
         using var listener = new LoopbackHttpListener(0, RedirectPath);
         using var cts = new CancellationTokenSource(s_timeout);
 
-        var waitTask = listener.WaitForCallbackAsync(Html("<html>ok</html>"), cts.Token);
+        var waitTask = listener.WaitForCallbackAsync(null, Html("<html>ok</html>"), cts.Token);
 
         // Any local process can connect to the port and claim any authority it likes; the callback
         // uri handed to the application must describe the socket the request actually arrived on.
@@ -246,12 +249,69 @@ public class LoopbackHttpListenerTests
     }
 
     [Fact]
+    public async Task Should_Reject_A_Filtered_Callback_And_Keep_Listening()
+    {
+        var handlerCalls = 0;
+
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(
+            uri => uri.Query.Contains("state=mine", StringComparison.Ordinal),
+            (_, response) =>
+            {
+                Interlocked.Increment(ref handlerCalls);
+                return WriteAsync(response, "<html>ok</html>");
+            },
+            cts.Token);
+
+        using var http = new HttpClient();
+
+        // A callback that isn't ours must be indistinguishable from a request to an unrelated path.
+        using var rejected = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=evil&state=theirs", cts.Token);
+        Assert.Equal(HttpStatusCode.NotFound, rejected.StatusCode);
+        Assert.False(waitTask.IsCompleted, "A rejected callback must not end the flow.");
+        Assert.Equal(0, Volatile.Read(ref handlerCalls));
+        Assert.Equal(1, listener.RejectedCallbackCount);
+
+        // The real callback still completes it.
+        using var accepted = await http.GetAsync(
+            $"http://127.0.0.1:{listener.Port}{RedirectPath}?code=real&state=mine", cts.Token);
+        Assert.Equal(HttpStatusCode.OK, accepted.StatusCode);
+
+        var uri = await waitTask;
+        Assert.Equal("?code=real&state=mine", uri.Query);
+        Assert.Equal(1, Volatile.Read(ref handlerCalls));
+        Assert.Equal(1, listener.RejectedCallbackCount);
+    }
+
+    [Fact]
+    public async Task Should_Surface_An_Exception_Thrown_By_The_Filter()
+    {
+        var expected = new InvalidOperationException("bad filter");
+
+        using var listener = new LoopbackHttpListener(0, RedirectPath);
+        using var cts = new CancellationTokenSource(s_timeout);
+
+        var waitTask = listener.WaitForCallbackAsync(_ => throw expected, null, cts.Token);
+
+        // The listener faults before writing a response, so send raw rather than waiting on HttpClient
+        // for a reply that never comes.
+        await SendRawRequestAsync(listener.Port,
+            $"GET {RedirectPath}?code=abc HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+            cts.Token);
+
+        Assert.Same(expected, await Assert.ThrowsAsync<InvalidOperationException>(() => waitTask));
+    }
+
+    [Fact]
     public async Task Should_Respect_Cancellation()
     {
         using var listener = new LoopbackHttpListener(0, RedirectPath);
         using var cts = new CancellationTokenSource();
 
-        var waitTask = listener.WaitForCallbackAsync(null, cts.Token);
+        var waitTask = listener.WaitForCallbackAsync(null, null, cts.Token);
 
         await cts.CancelAsync();
 

--- a/tests/Avalonia.Controls.WebView.Tests/SystemBrowserWebAuthenticationBrokerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/SystemBrowserWebAuthenticationBrokerTests.cs
@@ -97,6 +97,40 @@ public class SystemBrowserWebAuthenticationBrokerTests
     }
 
     [Fact]
+    public async Task Should_Accept_A_Localhost_Redirect_Uri()
+    {
+        var redirectUri = new Uri("http://localhost/callback");
+        var requestUri = new Uri("http://input.com/authorize?client_id=abc&redirect_uri=" +
+                                 Uri.EscapeDataString(redirectUri.AbsoluteUri));
+
+        Uri? launchedUri = null;
+
+        var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            requestUri,
+            redirectUri,
+            s_timeout,
+            async uri =>
+            {
+                launchedUri = uri;
+                await GetAsync(RedirectUriOf(uri) + "?code=123");
+                return true;
+            },
+            null,
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(launchedUri);
+
+        // The rewritten redirect_uri and the callback must both keep the configured host, so the token
+        // exchange can present the same string the authorization request carried.
+        var actualRedirectUri = new Uri(RedirectUriOf(launchedUri));
+        Assert.Equal("localhost", actualRedirectUri.Host);
+        Assert.Equal("localhost", callbackUri.Host);
+        Assert.Equal(actualRedirectUri.Port, callbackUri.Port);
+        Assert.Equal("?code=123", callbackUri.Query);
+    }
+
+    [Fact]
     public async Task Should_Send_The_Response_Produced_By_The_Response_Handler()
     {
         Uri? handlerUri = null;
@@ -365,7 +399,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 TestContext.Current.CancellationToken));
 
         // The listener must not keep the port bound after the flow is over.
-        using var listener = new LoopbackHttpListener(port, "/callback");
+        using var listener = new LoopbackHttpListener(new Uri($"http://127.0.0.1:{port}/callback"));
         Assert.Equal(port, listener.Port);
     }
 

--- a/tests/Avalonia.Controls.WebView.Tests/SystemBrowserWebAuthenticationBrokerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/SystemBrowserWebAuthenticationBrokerTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Avalonia.Controls.Authentication;
+using Xunit;
+
+namespace Avalonia.Controls.WebView.Tests;
+
+/// <summary>
+/// Covers the loopback browser flow directly, because <see cref="WebAuthenticationBroker"/> resolves the
+/// browser launcher from <c>TopLevel.Launcher</c> and therefore cannot be driven end to end from a test.
+/// </summary>
+public class SystemBrowserWebAuthenticationBrokerTests
+{
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(30);
+
+    private static readonly Uri s_defaultRedirectUri = new("http://127.0.0.1/callback");
+
+    [Fact]
+    public async Task Should_Complete_Flow_And_Preserve_The_Other_Request_Parameters()
+    {
+        var requestUri = new Uri(
+            "http://input.com/authorize?client_id=abc&scope=openid&state=xyz&redirect_uri=" +
+            Uri.EscapeDataString(s_defaultRedirectUri.AbsoluteUri));
+
+        Uri? launchedUri = null;
+
+        var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            requestUri,
+            s_defaultRedirectUri,
+            s_timeout,
+            async uri =>
+            {
+                launchedUri = uri;
+                await GetAsync(RedirectUriOf(uri) + "?code=123&state=xyz");
+                return true;
+            },
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(launchedUri);
+
+        // The dynamically allocated port must be pushed into the request's redirect_uri...
+        var actualRedirectUri = new Uri(RedirectUriOf(launchedUri));
+        Assert.Equal("127.0.0.1", actualRedirectUri.Host);
+        Assert.Equal("/callback", actualRedirectUri.AbsolutePath);
+        Assert.NotEqual(80, actualRedirectUri.Port);
+
+        // ...without dropping the rest of the authorization request.
+        var query = HttpUtility.ParseQueryString(launchedUri.Query);
+        Assert.Equal("abc", query["client_id"]);
+        Assert.Equal("openid", query["scope"]);
+        Assert.Equal("xyz", query["state"]);
+        Assert.Equal("input.com", launchedUri.Host);
+        Assert.Equal("/authorize", launchedUri.AbsolutePath);
+
+        Assert.Equal("/callback", callbackUri.AbsolutePath);
+        Assert.Equal("?code=123&state=xyz", callbackUri.Query);
+        Assert.Equal(actualRedirectUri.Port, callbackUri.Port);
+    }
+
+    [Fact]
+    public async Task Should_Bind_The_Explicit_Port_Of_The_Redirect_Uri()
+    {
+        var port = GetFreePort();
+        var redirectUri = new Uri($"http://127.0.0.1:{port}/callback");
+        var requestUri = new Uri("http://input.com/authorize?client_id=abc");
+
+        Uri? launchedUri = null;
+
+        var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            requestUri,
+            redirectUri,
+            s_timeout,
+            async uri =>
+            {
+                launchedUri = uri;
+                await GetAsync($"{redirectUri}?code=123");
+                return true;
+            },
+            null,
+            TestContext.Current.CancellationToken);
+
+        // An explicit port needs no coercion, so the request uri is passed through untouched.
+        Assert.Equal(requestUri, launchedUri);
+        Assert.Equal(port, callbackUri.Port);
+        Assert.Equal("?code=123", callbackUri.Query);
+    }
+
+    [Fact]
+    public async Task Should_Send_The_Response_Produced_By_The_Response_Handler()
+    {
+        Uri? handlerUri = null;
+        string? body = null;
+
+        var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            new Uri("http://input.com/authorize?redirect_uri=" +
+                    Uri.EscapeDataString(s_defaultRedirectUri.AbsoluteUri)),
+            s_defaultRedirectUri,
+            s_timeout,
+            async uri =>
+            {
+                body = await GetAsync(RedirectUriOf(uri) + "?code=123");
+                return true;
+            },
+            async (uri, response) =>
+            {
+                handlerUri = uri;
+                await response.OutputStream.WriteAsync(Encoding.UTF8.GetBytes("<html>done</html>"));
+            },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("<html>done</html>", body);
+        Assert.Equal(callbackUri, handlerUri);
+    }
+
+    [Theory]
+    [InlineData("https://127.0.0.1:5000/callback")]
+    [InlineData("http://example.com/callback")]
+    [InlineData("myapp://callback")]
+    public async Task Should_Reject_Non_Loopback_Http_Redirect_Uri(string redirectUri)
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com"),
+                new Uri(redirectUri),
+                s_timeout,
+                _ => throw new InvalidOperationException("Browser should not be launched."),
+                null,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("redirectUri", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_Throw_When_The_Request_Uri_Has_No_Redirect_Uri_To_Coerce()
+    {
+        // The redirect uri has no explicit port, so the request's redirect_uri has to be rewritten
+        // with the dynamically allocated one - and there is nothing to rewrite here.
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                s_defaultRedirectUri,
+                s_timeout,
+                _ => throw new InvalidOperationException("Browser should not be launched."),
+                null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Should_Throw_When_The_Browser_Cannot_Be_Launched()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                new Uri($"http://127.0.0.1:{GetFreePort()}/callback"),
+                s_timeout,
+                _ => Task.FromResult(false),
+                null,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("system browser", exception.Message);
+    }
+
+    [Fact]
+    public async Task Should_Wrap_The_Exception_Thrown_By_The_Launcher()
+    {
+        var expected = new NotSupportedException("no browser here");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                new Uri($"http://127.0.0.1:{GetFreePort()}/callback"),
+                s_timeout,
+                _ => throw expected,
+                null,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task Should_Cancel_When_The_Callback_Times_Out()
+    {
+        // The user never completes the flow in the browser.
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                new Uri($"http://127.0.0.1:{GetFreePort()}/callback"),
+                TimeSpan.FromMilliseconds(200),
+                _ => Task.FromResult(true),
+                null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Should_Cancel_When_The_Caller_Cancels()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var task = SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            new Uri("http://input.com/authorize?client_id=abc"),
+            new Uri($"http://127.0.0.1:{GetFreePort()}/callback"),
+            s_timeout,
+            _ =>
+            {
+                cts.Cancel();
+                return Task.FromResult(true);
+            },
+            null,
+            cts.Token);
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+
+        // Caller cancellation must not be reported as a timeout.
+        Assert.DoesNotContain("Timed out", exception.Message);
+    }
+
+    [Fact]
+    public async Task Should_Release_The_Port_When_The_Flow_Fails()
+    {
+        var port = GetFreePort();
+        var redirectUri = new Uri($"http://127.0.0.1:{port}/callback");
+
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                redirectUri,
+                TimeSpan.FromMilliseconds(200),
+                _ => Task.FromResult(true),
+                null,
+                TestContext.Current.CancellationToken));
+
+        // The listener must not keep the port bound after the flow is over.
+        using var listener = new LoopbackHttpListener(port, "/callback");
+        Assert.Equal(port, listener.Port);
+    }
+
+    private static string RedirectUriOf(Uri requestUri) =>
+        HttpUtility.ParseQueryString(requestUri.Query)["redirect_uri"] ??
+        throw new InvalidOperationException("The launched uri has no redirect_uri.");
+
+    private static async Task<string> GetAsync(string uri)
+    {
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(uri);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tests/Avalonia.Controls.WebView.Tests/SystemBrowserWebAuthenticationBrokerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/SystemBrowserWebAuthenticationBrokerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -40,6 +42,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 await GetAsync(RedirectUriOf(uri) + "?code=123&state=xyz");
                 return true;
             },
+            null,
             null,
             TestContext.Current.CancellationToken);
 
@@ -84,6 +87,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 return true;
             },
             null,
+            null,
             TestContext.Current.CancellationToken);
 
         // An explicit port needs no coercion, so the request uri is passed through untouched.
@@ -108,6 +112,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 body = await GetAsync(RedirectUriOf(uri) + "?code=123");
                 return true;
             },
+            null,
             async (uri, response) =>
             {
                 handlerUri = uri;
@@ -117,6 +122,122 @@ public class SystemBrowserWebAuthenticationBrokerTests
 
         Assert.Equal("<html>done</html>", body);
         Assert.Equal(callbackUri, handlerUri);
+    }
+
+    [Fact]
+    public async Task Should_Ignore_A_Forged_Callback_That_Arrives_Before_The_Real_One()
+    {
+        var port = GetFreePort();
+        var redirectUri = new Uri($"http://127.0.0.1:{port}/callback");
+        var rejected = new List<Uri>();
+
+        var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            new Uri("http://input.com/authorize?client_id=abc&state=mine"),
+            redirectUri,
+            s_timeout,
+            async _ =>
+            {
+                // Any local process can reach the port and race the browser to it.
+                await GetAsync($"{redirectUri}?code=evil&state=theirs");
+                await GetAsync($"{redirectUri}?code=real&state=mine");
+                return true;
+            },
+            uri =>
+            {
+                var accepted = HttpUtility.ParseQueryString(uri.Query)["state"] == "mine";
+                if (!accepted)
+                {
+                    rejected.Add(uri);
+                }
+
+                return accepted;
+            },
+            null,
+            TestContext.Current.CancellationToken);
+
+        // The forged callback must neither complete nor kill the flow.
+        Assert.Equal("?code=real&state=mine", callbackUri.Query);
+        Assert.Equal("?code=evil&state=theirs", Assert.Single(rejected).Query);
+    }
+
+    [Fact]
+    public async Task Should_Not_Invoke_The_Response_Handler_For_A_Rejected_Callback()
+    {
+        var port = GetFreePort();
+        var redirectUri = new Uri($"http://127.0.0.1:{port}/callback");
+        var handlerCalls = 0;
+
+        var callbackUri = await SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+            new Uri("http://input.com/authorize?client_id=abc&state=mine"),
+            redirectUri,
+            s_timeout,
+            async _ =>
+            {
+                await GetAsync($"{redirectUri}?code=evil&state=theirs");
+                await GetAsync($"{redirectUri}?code=real&state=mine");
+                return true;
+            },
+            uri => HttpUtility.ParseQueryString(uri.Query)["state"] == "mine",
+            (_, _) =>
+            {
+                handlerCalls++;
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("?code=real&state=mine", callbackUri.Query);
+        Assert.Equal(1, handlerCalls);
+    }
+
+    [Fact]
+    public async Task Should_Report_Rejected_Callbacks_In_The_Timeout_Message()
+    {
+        var port = GetFreePort();
+        var redirectUri = new Uri($"http://127.0.0.1:{port}/callback");
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                redirectUri,
+                TimeSpan.FromSeconds(2),
+                async _ =>
+                {
+                    await GetAsync($"{redirectUri}?code=one");
+                    await GetAsync($"{redirectUri}?code=two");
+                    return true;
+                },
+                _ => false,
+                null,
+                TestContext.Current.CancellationToken));
+
+        // A filter that never matches must not present as a silent wait.
+        Assert.Contains("2 callback(s) were rejected by the callback filter.", exception.Message);
+    }
+
+    [Fact]
+    public async Task Should_Surface_An_Exception_Thrown_By_The_Callback_Filter()
+    {
+        var port = GetFreePort();
+        var redirectUri = new Uri($"http://127.0.0.1:{port}/callback");
+        var expected = new InvalidOperationException("bad filter");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SystemBrowserWebAuthenticationBroker.AuthenticateAsync(
+                new Uri("http://input.com/authorize?client_id=abc"),
+                redirectUri,
+                s_timeout,
+                async _ =>
+                {
+                    // The listener faults before writing a response, so send raw rather than waiting on
+                    // HttpClient for a reply that never comes.
+                    await SendRawCallbackAsync(port, "/callback?code=abc");
+                    return true;
+                },
+                _ => throw expected,
+                null,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, exception);
     }
 
     [Theory]
@@ -131,6 +252,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 new Uri(redirectUri),
                 s_timeout,
                 _ => throw new InvalidOperationException("Browser should not be launched."),
+                null,
                 null,
                 TestContext.Current.CancellationToken));
 
@@ -149,6 +271,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 s_timeout,
                 _ => throw new InvalidOperationException("Browser should not be launched."),
                 null,
+                null,
                 TestContext.Current.CancellationToken));
     }
 
@@ -161,6 +284,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 new Uri($"http://127.0.0.1:{GetFreePort()}/callback"),
                 s_timeout,
                 _ => Task.FromResult(false),
+                null,
                 null,
                 TestContext.Current.CancellationToken));
 
@@ -179,6 +303,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 s_timeout,
                 _ => throw expected,
                 null,
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Same(expected, exception.InnerException);
@@ -194,6 +319,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 new Uri($"http://127.0.0.1:{GetFreePort()}/callback"),
                 TimeSpan.FromMilliseconds(200),
                 _ => Task.FromResult(true),
+                null,
                 null,
                 TestContext.Current.CancellationToken));
     }
@@ -212,6 +338,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 cts.Cancel();
                 return Task.FromResult(true);
             },
+            null,
             null,
             cts.Token);
 
@@ -234,6 +361,7 @@ public class SystemBrowserWebAuthenticationBrokerTests
                 TimeSpan.FromMilliseconds(200),
                 _ => Task.FromResult(true),
                 null,
+                null,
                 TestContext.Current.CancellationToken));
 
         // The listener must not keep the port bound after the flow is over.
@@ -245,9 +373,28 @@ public class SystemBrowserWebAuthenticationBrokerTests
         HttpUtility.ParseQueryString(requestUri.Query)["redirect_uri"] ??
         throw new InvalidOperationException("The launched uri has no redirect_uri.");
 
+    /// <summary>
+    /// Sends a callback request without expecting a well formed reply, and returns once the listener
+    /// closes the connection.
+    /// </summary>
+    private static async Task SendRawCallbackAsync(int port, string target)
+    {
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+
+        var stream = client.GetStream();
+        await stream.WriteAsync(Encoding.ASCII.GetBytes($"GET {target} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"));
+        await stream.FlushAsync();
+
+        using var drain = new MemoryStream();
+        await stream.CopyToAsync(drain);
+    }
+
     private static async Task<string> GetAsync(string uri)
     {
-        using var http = new HttpClient();
+        // Short timeout so a listener that stopped accepting fails the test quickly
+        // instead of waiting out HttpClient's 100 second default.
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
         using var response = await http.GetAsync(uri);
         return await response.Content.ReadAsStringAsync();
     }

--- a/tests/Avalonia.Controls.WebView.Tests/WebAuthenticationBrokerTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/WebAuthenticationBrokerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Avalonia.Headless.XUnit;
 using Avalonia.Platform;
@@ -14,13 +14,69 @@ public class WebAuthenticationBrokerTests : HeadlessTestsBase
         var window = new Window();
         window.Show();
 
-        var inputUri = new Uri("http://input.com");
-        var middleUri = new Uri("http://middle.com");
-        var outputUri = new Uri("http://localhost");
-        var extraArgs = new Uri("/?code=123", UriKind.Relative);
-        var options = new WebAuthenticatorOptions(inputUri, outputUri)
+#pragma warning disable CA1416
+        var options = CreateDialogOptions() with { Mode = WebAuthenticatorMode.NativeWebDialog };
+#pragma warning restore CA1416
+
+        var result = await WebAuthenticationBroker.AuthenticateAsync(window, options);
+        Assert.Equal(ExpectedCallbackUri, result.CallbackUri);
+    }
+
+    // The completion path of WebAuthenticatorMode.Browser is covered by
+    // SystemBrowserWebAuthenticationBrokerTests: the broker takes its launcher from TopLevel.Launcher,
+    // which cannot be substituted, so only the paths that reject before launching are testable here.
+
+    [AvaloniaTheory(Timeout = 10_000)]
+    [InlineData("https://127.0.0.1:5000/callback")]
+    [InlineData("http://example.com/callback")]
+    [InlineData("myapp://callback")]
+    public async Task Should_Reject_Non_Loopback_Http_Redirect_Uri(string redirectUri)
+    {
+        var window = new Window();
+        window.Show();
+
+        var options = new WebAuthenticatorOptions(new Uri("http://input.com"), new Uri(redirectUri))
         {
-            PreferNativeWebDialog = true,
+            Mode = WebAuthenticatorMode.Browser,
+            BrowserOptions = new BrowserOptions
+            {
+                ResponseHandler = (_, _) => throw new InvalidOperationException("Callback should not be received.")
+            }
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => WebAuthenticationBroker.AuthenticateAsync(window, options));
+        Assert.Equal("redirectUri", exception.ParamName);
+    }
+
+    [AvaloniaFact(Timeout = 30_000)]
+    public async Task Should_Throw_When_The_Browser_Cannot_Be_Launched()
+    {
+        var window = new Window();
+        window.Show();
+
+        // The headless platform exposes no ILauncher, so LaunchUriAsync reports failure.
+        var options = new WebAuthenticatorOptions(
+            new Uri("http://input.com"), new Uri($"http://127.0.0.1:{GetFreePort()}/callback"))
+        {
+            Mode = WebAuthenticatorMode.Browser,
+            BrowserOptions = new BrowserOptions { Timeout = TimeSpan.FromSeconds(5) }
+        };
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => WebAuthenticationBroker.AuthenticateAsync(window, options));
+    }
+
+    private static readonly Uri s_inputUri = new("http://input.com");
+    private static readonly Uri s_middleUri = new("http://middle.com");
+    private static readonly Uri s_outputUri = new("http://localhost");
+    private static readonly Uri s_extraArgs = new("/?code=123", UriKind.Relative);
+
+    private static Uri ExpectedCallbackUri => new(s_outputUri, s_extraArgs);
+
+    private static WebAuthenticatorOptions CreateDialogOptions() =>
+        new(s_inputUri, s_outputUri)
+        {
             NativeWebDialogFactory = () =>
             {
                 var dialog = new NativeWebDialog();
@@ -33,13 +89,13 @@ public class WebAuthenticationBrokerTests : HeadlessTestsBase
                         headless.HttpHandler = async uri =>
                         {
                             await Task.Delay(10);
-                            if (uri == inputUri)
+                            if (uri == s_inputUri)
                                 return new HeadlessWebViewEnvironmentRequestedEventArgs.HttpResult(
-                                    true, RedirectUri: middleUri);
-                            if (uri == middleUri)
+                                    true, RedirectUri: s_middleUri);
+                            if (uri == s_middleUri)
                                 return new HeadlessWebViewEnvironmentRequestedEventArgs.HttpResult(
-                                    true, RedirectUri: new Uri(outputUri, extraArgs));
-                            if (uri.ToString().StartsWith(outputUri.ToString()))
+                                    true, RedirectUri: new Uri(s_outputUri, s_extraArgs));
+                            if (uri.ToString().StartsWith(s_outputUri.ToString()))
                                 Assert.Fail("Final localhost request should be canceled.");
                             return new HeadlessWebViewEnvironmentRequestedEventArgs.HttpResult(false);
                         };
@@ -49,7 +105,12 @@ public class WebAuthenticationBrokerTests : HeadlessTestsBase
             }
         };
 
-        var result = await WebAuthenticationBroker.AuthenticateAsync(window, options);
-        Assert.Equal(new Uri(outputUri, extraArgs), result.CallbackUri);
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
     }
 }


### PR DESCRIPTION
Closes https://github.com/AvaloniaUI/Avalonia.Controls.WebView/issues/26

System OAuth WebAuthenticationBroker implementation is not always available. And NativeWebDialog implementation might not be desirable (as it's not connected with user browser sessions).

In the wild, many apps implement HTTP listener, including our own tooling. This new WebAuthenticationBroker brings the same fallback to this library.

New API:

```diff
public record WebAuthenticatorOptions(Uri RequestUri, Uri RedirectUri)
{
+   public WebAuthenticatorMode Mode { get; init; }

+   [Obsolete("Use Mode = WebAuthenticatorMode.NativeWebDialog instead.")]
    public bool PreferNativeWebDialog { get; init; }

    public bool NonPersistent { get; init; }

    public Func<NativeWebDialog?>? NativeWebDialogFactory { get; init; }

+   public BrowserOptions? BrowserOptions { get; init; }
}
```

```csharp
public enum WebAuthenticatorMode
{
    Auto,

    [SupportedOSPlatform("macos")]
    [SupportedOSPlatform("ios")]
    [SupportedOSPlatform("android")]
    [SupportedOSPlatform("browser")]
    System,

    [SupportedOSPlatform("windows")]
    [SupportedOSPlatform("macos")]
    [SupportedOSPlatform("android")]
    [SupportedOSPlatform("linux")]
    NativeWebDialog,

    [UnsupportedOSPlatform("browser")]
    Browser
}

public record BrowserOptions
{
    public TimeSpan Timeout { get; init; } = TimeSpan.FromMinutes(5);

    public BrowserResponseHandler? ResponseHandler { get; init; }

    public BrowserCallbackFilter? CallbackFilter { get; init; }

    public delegate Task BrowserResponseHandler(
        WebAuthenticationResult result, BrowserResponse response);

    public delegate bool BrowserCallbackFilter(
        WebAuthenticationResult result);
}

public sealed class BrowserResponse
{
    public HttpStatusCode StatusCode { get; set; }
    public Stream OutputStream { get; }
    public void Redirect(Uri uri)
}
```