### PR TITLE
Add Blazor Hybrid package and local-content WebView APIs

### DIFF
--- a/Avalonia.Controls.WebView.slnx
+++ b/Avalonia.Controls.WebView.slnx
@@ -10,8 +10,9 @@
       <Build Solution="*|Any CPU" Project="false" />
     </Project>
   </Folder>
-  <Folder Name="/Samples/">
+    <Folder Name="/Samples/">
     <File Path="samples/NuGet.config" />
+    <Project Path="samples/Avalonia.Controls.BlazorWebView.Samples/Avalonia.Controls.BlazorWebView.Samples.csproj" />
     <Project Path="samples/Avalonia.Controls.WebView.Samples.Android/Avalonia.Controls.WebView.Samples.Android.csproj">
       <Deploy Solution="Debug|Any CPU" />
     </Project>
@@ -37,6 +38,7 @@
     <Project Path="tests/Avalonia.Controls.WebView.Tests/Avalonia.Controls.WebView.Tests.csproj" />
   </Folder>
   <Folder Name="/WebView/">
+    <Project Path="src/Avalonia.Controls.BlazorWebView/Avalonia.Controls.BlazorWebView.csproj" />
     <Project Path="src/Avalonia.Controls.WebView.Core/Avalonia.Controls.WebView.Core.csproj" />
     <Project Path="src/Avalonia.Controls.WebView/Avalonia.Controls.WebView.csproj" />
     <Project Path="src/Avalonia.Xpf.Controls.WebView/Avalonia.Xpf.Controls.WebView.csproj" />

--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,10 @@ See [`avalonia-docs`](https://docs.avaloniaui.net/docs/app-development/embedding
 
 Avalonia specific project
 
+### Avalonia.Controls.BlazorWebView
+
+Separate NuGet package for Blazor Hybrid over `NativeWebView` (reuses `Microsoft.AspNetCore.Components.WebView`).
+
 ### Avalonia.Xpf.Controls.WebView
 
 XPF/WPF specific project.

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/App.axaml
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/App.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Avalonia.Controls.BlazorWebView.Samples.App">
+    <Application.Styles>
+        <!--<FluentTheme />-->
+    </Application.Styles>
+</Application>

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/App.axaml.cs
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/App.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace Avalonia.Controls.BlazorWebView.Samples;
+
+public class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            desktop.MainWindow = new MainWindow();
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/Avalonia.Controls.BlazorWebView.Samples.csproj
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/Avalonia.Controls.BlazorWebView.Samples.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!-- Embed wwwroot into the assembly so publish output has no wwwroot folder. -->
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <!-- Avoid Razor SDK creating an empty wwwroot next to the app; assets are embedded. -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaSampleVersion)" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.Controls.BlazorWebView\Avalonia.Controls.BlazorWebView.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Do not copy wwwroot to output; serve via ManifestEmbeddedFileProvider. -->
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Include="wwwroot\**" />
+  </ItemGroup>
+</Project>

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/Counter.razor
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/Counter.razor
@@ -1,0 +1,13 @@
+@namespace Avalonia.Controls.BlazorWebView.Samples
+
+<h1>Avalonia Blazor Hybrid</h1>
+
+<p>Current count: @currentCount</p>
+
+<button class="btn" @onclick="Increment">Click me</button>
+
+@code {
+    private int currentCount;
+
+    private void Increment() => currentCount++;
+}

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/EmbeddedBlazorWebView.cs
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/EmbeddedBlazorWebView.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Avalonia.Controls.BlazorWebView.Samples;
+
+/// <summary>
+/// Serves <c>wwwroot</c> from embedded resources so publish output does not need a physical wwwroot folder.
+/// </summary>
+public sealed class EmbeddedBlazorWebView : BlazorWebView
+{
+    protected override IFileProvider CreateFileProvider(string contentRootDir)
+    {
+        // Resource root matches the wwwroot folder embedded via GenerateEmbeddedFilesManifest.
+        var embedded = new ManifestEmbeddedFileProvider(typeof(Program).Assembly, "wwwroot");
+        var physical = base.CreateFileProvider(contentRootDir);
+        return new CompositeFileProvider(embedded, physical);
+    }
+}

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/MainWindow.cs
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/MainWindow.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls;
+using Avalonia.Controls.BlazorWebView;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Avalonia.Controls.BlazorWebView.Samples;
+
+public class MainWindow : Window
+{
+    public MainWindow()
+    {
+        Title = "Avalonia Blazor Hybrid";
+        Width = 900;
+        Height = 600;
+        Background = Avalonia.Media.Brushes.White;
+
+        var services = new ServiceCollection();
+        services.AddAvaloniaBlazorWebView();
+        var provider = services.BuildServiceProvider();
+
+        var blazor = new EmbeddedBlazorWebView
+        {
+            Services = provider,
+            // Logical path only; CreateFileProvider serves wwwroot from embedded resources.
+            HostPage = Path.Combine("wwwroot", "index.html"),
+        };
+        blazor.RootComponents.Add(new RootComponent
+        {
+            Selector = "#app",
+            ComponentType = typeof(Counter),
+        });
+
+        Content = blazor;
+    }
+}

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/Program.cs
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/Program.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Avalonia.Controls.BlazorWebView.Samples;
+
+internal static class Program
+{
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/_Imports.razor
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/_Imports.razor
@@ -1,0 +1,1 @@
+@using Microsoft.AspNetCore.Components.Web

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/app.manifest
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Avalonia.Controls.BlazorWebView.Samples"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/samples/Avalonia.Controls.BlazorWebView.Samples/wwwroot/index.html
+++ b/samples/Avalonia.Controls.BlazorWebView.Samples/wwwroot/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Avalonia Blazor Hybrid</title>
+  <base href="/" />
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; }
+    .btn { padding: 0.5rem 1rem; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <div id="app">Loading...</div>
+  <script src="_framework/blazor.webview.js"></script>
+</body>
+</html>

--- a/src/Avalonia.Controls.BlazorWebView/Avalonia.Controls.BlazorWebView.csproj
+++ b/src/Avalonia.Controls.BlazorWebView/Avalonia.Controls.BlazorWebView.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Description>Blazor Hybrid hosting for Avalonia using Avalonia.Controls.WebView (NativeWebView).</Description>
+    <RootNamespace>Avalonia.Controls.BlazorWebView</RootNamespace>
+    <PackageId>Avalonia.Controls.BlazorWebView</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IsPackable>true</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Avalonia.Controls.WebView\Avalonia.Controls.WebView.csproj" />
+    <ProjectReference Include="..\Avalonia.Controls.WebView.Core\Avalonia.Controls.WebView.Core.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+  </ItemGroup>
+</Project>

--- a/src/Avalonia.Controls.BlazorWebView/AvaloniaBlazorWebViewManager.cs
+++ b/src/Avalonia.Controls.BlazorWebView/AvaloniaBlazorWebViewManager.cs
@@ -1,0 +1,156 @@
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebView;
+using Microsoft.Extensions.FileProviders;
+using AvControls = Avalonia.Controls;
+
+namespace Avalonia.Controls.BlazorWebView;
+
+/// <summary>
+/// <see cref="WebViewManager"/> implementation over Avalonia <see cref="AvControls.NativeWebView"/>.
+/// </summary>
+internal sealed class AvaloniaBlazorWebViewManager : WebViewManager
+{
+    // On Windows, WebView2 cannot navigate top-level to a custom scheme.
+    // On WebKit platforms, http interception is unavailable - use app://.
+    internal static readonly string BlazorAppScheme = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? "http"
+        : "app";
+
+    internal static readonly Uri AppBaseUri = new($"{BlazorAppScheme}://0.0.0.0/");
+
+    private readonly AvControls.NativeWebView _webView;
+    private readonly Uri _appBaseUri;
+
+    public AvaloniaBlazorWebViewManager(
+        AvControls.NativeWebView webView,
+        IServiceProvider provider,
+        Dispatcher dispatcher,
+        Uri appBaseUri,
+        IFileProvider fileProvider,
+        JSComponentConfigurationStore jsComponents,
+        string hostPageRelativePath)
+        : base(provider, dispatcher, appBaseUri, fileProvider, jsComponents, hostPageRelativePath)
+    {
+        _webView = webView;
+        _appBaseUri = appBaseUri;
+
+        _webView.WebMessageReceived += OnWebMessageReceived;
+        _webView.WebResourceRequested += OnWebResourceRequested;
+    }
+
+    protected override void NavigateCore(Uri absoluteUri) => _webView.Navigate(absoluteUri);
+
+    protected override void SendMessage(string message)
+    {
+        // Deliver into Blazor's window.external.receiveMessage callback(s).
+        var payload = EscapeJsString(message);
+        _ = _webView.InvokeScript(
+            $"(function(){{var cbs=window.__blazorExternalMessageCallbacks;if(cbs){{for(var i=0;i<cbs.length;i++){{cbs[i]({payload});}}}}}})()");
+    }
+
+    private static string EscapeJsString(string value)
+    {
+        var sb = new System.Text.StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\u2028': sb.Append("\\u2028"); break;
+                case '\u2029': sb.Append("\\u2029"); break;
+                default:
+                    if (c < 0x20)
+                        sb.Append("\\u").Append(((int)c).ToString("x4"));
+                    else
+                        sb.Append(c);
+                    break;
+            }
+        }
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    private void OnWebMessageReceived(object? sender, AvControls.WebMessageReceivedEventArgs e)
+    {
+        if (e.Body is { } body)
+            MessageReceived(_appBaseUri, body);
+    }
+
+    private void OnWebResourceRequested(object? sender, AvControls.WebResourceRequestedEventArgs e)
+    {
+        var url = e.Request.Uri.AbsoluteUri;
+        if (!_appBaseUri.IsBaseOf(e.Request.Uri))
+            return;
+
+        var hasFileExtension = url.LastIndexOf('.') > url.LastIndexOf('/');
+        if (TryGetResponseContent(
+                url,
+                !hasFileExtension,
+                out var statusCode,
+                out var statusMessage,
+                out var content,
+                out var headers))
+        {
+            var contentType = GetContentType(headers);
+            if (contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+            {
+                content = InjectExternalBridgePolyfill(content);
+                headers = new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+                headers.Remove("Content-Length");
+            }
+
+            e.SetResponse(content, statusCode, statusMessage, contentType,
+                (IReadOnlyDictionary<string, string>)new Dictionary<string, string>(headers));
+        }
+    }
+
+    private static Stream InjectExternalBridgePolyfill(Stream content)
+    {
+        using var reader = new StreamReader(content);
+        var html = reader.ReadToEnd();
+        const string polyfill =
+            "<script>(function(){" +
+            "window.__blazorExternalMessageCallbacks=window.__blazorExternalMessageCallbacks||[];" +
+            "window.external=window.external||{};" +
+            "window.external.sendMessage=window.external.sendMessage||function(m){if(window.invokeCSharpAction)window.invokeCSharpAction(typeof m==='string'?m:JSON.stringify(m));};" +
+            "window.external.receiveMessage=window.external.receiveMessage||function(cb){window.__blazorExternalMessageCallbacks.push(cb);};" +
+            "window.chrome=window.chrome||{};window.chrome.webview=window.chrome.webview||{};" +
+            "window.chrome.webview.postMessage=window.chrome.webview.postMessage||function(m){window.external.sendMessage(m);};" +
+            "window.chrome.webview.addEventListener=window.chrome.webview.addEventListener||function(t,h){if(t==='message'){window.external.receiveMessage(function(d){h({data:d});});}};" +
+            "})();</script>";
+
+        if (!html.Contains("window.external.sendMessage", StringComparison.Ordinal))
+        {
+            var idx = html.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
+            html = idx >= 0
+                ? html.Insert(idx + 6, polyfill)
+                : polyfill + html;
+        }
+
+        return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(html));
+    }
+
+    private static string GetContentType(IDictionary<string, string> headers)
+    {
+        foreach (var pair in headers)
+        {
+            if (pair.Key.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
+                return pair.Value;
+        }
+        return "application/octet-stream";
+    }
+
+    public async ValueTask DisposeManagedAsync()
+    {
+        _webView.WebMessageReceived -= OnWebMessageReceived;
+        _webView.WebResourceRequested -= OnWebResourceRequested;
+        await DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Avalonia.Controls.BlazorWebView/AvaloniaDispatcher.cs
+++ b/src/Avalonia.Controls.BlazorWebView/AvaloniaDispatcher.cs
@@ -1,0 +1,78 @@
+using System.Runtime.ExceptionServices;
+using Microsoft.AspNetCore.Components;
+using AvaloniaDispatcherUI = Avalonia.Threading.Dispatcher;
+
+namespace Avalonia.Controls.BlazorWebView;
+
+internal sealed class AvaloniaDispatcher : Dispatcher
+{
+    public static AvaloniaDispatcher Instance { get; } = new();
+
+    private AvaloniaDispatcher()
+    {
+    }
+
+    public override bool CheckAccess() => AvaloniaDispatcherUI.UIThread.CheckAccess();
+
+    public override async Task InvokeAsync(Action workItem)
+    {
+        try
+        {
+            if (CheckAccess())
+                workItem();
+            else
+                await AvaloniaDispatcherUI.UIThread.InvokeAsync(workItem);
+        }
+        catch (Exception ex)
+        {
+            ExceptionDispatchInfo.Capture(ex).Throw();
+            throw;
+        }
+    }
+
+    public override async Task InvokeAsync(Func<Task> workItem)
+    {
+        try
+        {
+            if (CheckAccess())
+                await workItem();
+            else
+                await AvaloniaDispatcherUI.UIThread.InvokeAsync(workItem);
+        }
+        catch (Exception ex)
+        {
+            ExceptionDispatchInfo.Capture(ex).Throw();
+            throw;
+        }
+    }
+
+    public override async Task<TResult> InvokeAsync<TResult>(Func<TResult> workItem)
+    {
+        try
+        {
+            if (CheckAccess())
+                return workItem();
+            return await AvaloniaDispatcherUI.UIThread.InvokeAsync(workItem);
+        }
+        catch (Exception ex)
+        {
+            ExceptionDispatchInfo.Capture(ex).Throw();
+            throw;
+        }
+    }
+
+    public override async Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> workItem)
+    {
+        try
+        {
+            if (CheckAccess())
+                return await workItem();
+            return await AvaloniaDispatcherUI.UIThread.InvokeAsync(workItem);
+        }
+        catch (Exception ex)
+        {
+            ExceptionDispatchInfo.Capture(ex).Throw();
+            throw;
+        }
+    }
+}

--- a/src/Avalonia.Controls.BlazorWebView/BlazorWebView.cs
+++ b/src/Avalonia.Controls.BlazorWebView/BlazorWebView.cs
@@ -1,0 +1,227 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Runtime.InteropServices;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using AvControls = Avalonia.Controls;
+
+namespace Avalonia.Controls.BlazorWebView;
+
+/// <summary>
+/// Hosts Blazor components inside an Avalonia <see cref="AvControls.NativeWebView"/>.
+/// </summary>
+public class BlazorWebView : Decorator, IAsyncDisposable
+{
+    private readonly AvControls.NativeWebView _webView = new();
+    private AvaloniaBlazorWebViewManager? _manager;
+    private bool _isInitialized;
+
+    /// <summary>
+    /// Path to the host page within the application's static files (for example <c>wwwroot/index.html</c>).
+    /// </summary>
+    public static readonly StyledProperty<string?> HostPageProperty =
+        AvaloniaProperty.Register<BlazorWebView, string?>(nameof(HostPage), "wwwroot/index.html");
+
+    /// <summary>
+    /// Application services used to create Blazor scopes. Must include Blazor WebView services
+    /// (for example via <c>services.AddAvaloniaBlazorWebView()</c>).
+    /// </summary>
+    public static readonly StyledProperty<IServiceProvider?> ServicesProperty =
+        AvaloniaProperty.Register<BlazorWebView, IServiceProvider?>(nameof(Services));
+
+    /// <summary>
+    /// Optional content root directory. Defaults to the application base directory.
+    /// </summary>
+    public static readonly StyledProperty<string?> ContentRootProperty =
+        AvaloniaProperty.Register<BlazorWebView, string?>(nameof(ContentRoot));
+
+    public BlazorWebView()
+    {
+        RootComponents = new ObservableCollection<RootComponent>();
+        RootComponents.CollectionChanged += OnRootComponentsChanged;
+        // Register custom scheme before the native adapter is created.
+        _webView.EnvironmentRequested += (_, e) =>
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                && !e.CustomSchemes.Contains(AvaloniaBlazorWebViewManager.BlazorAppScheme, StringComparer.OrdinalIgnoreCase))
+            {
+                e.CustomSchemes.Add(AvaloniaBlazorWebViewManager.BlazorAppScheme);
+            }
+        };
+        _webView.Background = Brushes.White;
+        Child = _webView;
+    }
+
+    /// <summary>
+    /// Path to the host page within the application's static files.
+    /// </summary>
+    public string? HostPage
+    {
+        get => GetValue(HostPageProperty);
+        set => SetValue(HostPageProperty, value);
+    }
+
+    /// <summary>
+    /// Application <see cref="IServiceProvider"/>.
+    /// </summary>
+    public IServiceProvider? Services
+    {
+        get => GetValue(ServicesProperty);
+        set => SetValue(ServicesProperty, value);
+    }
+
+    /// <summary>
+    /// Content root for static files. Defaults to <see cref="AppContext.BaseDirectory"/>.
+    /// </summary>
+    public string? ContentRoot
+    {
+        get => GetValue(ContentRootProperty);
+        set => SetValue(ContentRootProperty, value);
+    }
+
+    /// <summary>
+    /// Root components to render into the host page.
+    /// </summary>
+    public ObservableCollection<RootComponent> RootComponents { get; }
+
+    /// <summary>
+    /// The underlying <see cref="AvControls.NativeWebView"/>.
+    /// </summary>
+    public AvControls.NativeWebView WebView => _webView;
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        _ = StartAsync();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        _ = DisposeAsync();
+    }
+
+    private async Task StartAsync()
+    {
+        if (_isInitialized)
+            return;
+
+        try
+        {
+            await StartCoreAsync().ConfigureAwait(true);
+            _isInitialized = true;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to start BlazorWebView.", ex);
+        }
+    }
+
+    private async Task StartCoreAsync()
+    {
+        if (Services is null)
+            throw new InvalidOperationException($"{nameof(Services)} must be set before {nameof(BlazorWebView)} is shown.");
+
+        if (string.IsNullOrWhiteSpace(HostPage))
+            throw new InvalidOperationException($"{nameof(HostPage)} must be set.");
+
+        var contentRoot = ContentRoot ?? AppContext.BaseDirectory;
+        var hostPageFullPath = Path.GetFullPath(Path.IsPathRooted(HostPage)
+            ? HostPage
+            : Path.Combine(contentRoot, HostPage));
+
+        // Match WPF/MAUI: the file provider root is the directory that contains the host page (typically wwwroot).
+        // The physical path need not exist when CreateFileProvider serves embedded (or other) content.
+        var contentRootDir = Path.GetDirectoryName(hostPageFullPath)
+            ?? throw new InvalidOperationException("Unable to resolve the Blazor content root.");
+        var hostPageRelative = Path.GetRelativePath(contentRootDir, hostPageFullPath).Replace('\\', '/');
+        var fileProvider = CreateFileProvider(contentRootDir);
+
+        var jsComponents = new JSComponentConfigurationStore();
+        _manager = new AvaloniaBlazorWebViewManager(
+            _webView,
+            Services,
+            AvaloniaDispatcher.Instance,
+            AvaloniaBlazorWebViewManager.AppBaseUri,
+            fileProvider,
+            jsComponents,
+            hostPageRelative);
+
+        foreach (var root in RootComponents)
+        {
+            if (root.ComponentType is null)
+                continue;
+            await _manager.AddRootComponentAsync(root.ComponentType, root.Selector, root.ToParameterView());
+        }
+
+        _manager.Navigate("/");
+    }
+
+    /// <summary>
+    /// Creates the <see cref="IFileProvider"/> used for host-page and static assets under the content root
+    /// (typically <c>wwwroot</c>). Override to serve embedded resources instead of files on disk.
+    /// Combine with <see cref="CompositeFileProvider"/> if you also want the default physical provider.
+    /// Framework scripts such as <c>_framework/blazor.webview.js</c> are still served from
+    /// <c>Microsoft.AspNetCore.Components.WebView</c> embedded content.
+    /// </summary>
+    /// <param name="contentRootDir">Absolute path of the content root directory (may not exist on disk).</param>
+    protected virtual IFileProvider CreateFileProvider(string contentRootDir)
+    {
+        if (Directory.Exists(contentRootDir))
+            return new PhysicalFileProvider(contentRootDir);
+
+        // Development / embedded scenarios: host page and app assets come from a custom provider
+        // or Static Web Assets; framework files come from the WebView package.
+        return new NullFileProvider();
+    }
+
+    private async void OnRootComponentsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (_manager is null || !_isInitialized)
+            return;
+
+        if (e.NewItems is not null)
+        {
+            foreach (RootComponent root in e.NewItems)
+            {
+                if (root.ComponentType is null)
+                    continue;
+                await _manager.AddRootComponentAsync(root.ComponentType, root.Selector, root.ToParameterView());
+            }
+        }
+
+        if (e.OldItems is not null)
+        {
+            foreach (RootComponent root in e.OldItems)
+                await _manager.RemoveRootComponentAsync(root.Selector);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_manager is not null)
+        {
+            await _manager.DisposeManagedAsync();
+            _manager = null;
+        }
+        _isInitialized = false;
+    }
+}
+
+/// <summary>
+/// Service collection helpers for Avalonia Blazor Hybrid.
+/// </summary>
+public static class AvaloniaBlazorWebViewServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds Blazor WebView services required by <see cref="BlazorWebView"/>.
+    /// </summary>
+    public static IServiceCollection AddAvaloniaBlazorWebView(this IServiceCollection services)
+    {
+        services.AddBlazorWebView();
+        return services;
+    }
+}

--- a/src/Avalonia.Controls.BlazorWebView/README.md
+++ b/src/Avalonia.Controls.BlazorWebView/README.md
@@ -1,0 +1,85 @@
+# Avalonia.Controls.BlazorWebView
+
+Blazor Hybrid hosting for Avalonia applications using [`Avalonia.Controls.WebView`](https://www.nuget.org/packages/Avalonia.Controls.WebView) (`NativeWebView`).
+
+## Platforms
+
+| Platform | Origin | Notes |
+|----------|--------|--------|
+| Windows | `http://0.0.0.0/` | WebView2 response synthesis |
+| macOS / iOS | `app://0.0.0.0/` | Custom URI scheme |
+| Linux (GTK / WPE) | `app://0.0.0.0/` | Custom URI scheme |
+| Android | `app://0.0.0.0/` | `ShouldInterceptRequest` |
+
+Browser (WASM) iframe hosting is not supported.
+
+## Quick start
+
+```csharp
+var services = new ServiceCollection();
+services.AddAvaloniaBlazorWebView();
+var provider = services.BuildServiceProvider();
+
+var blazor = new BlazorWebView
+{
+    Services = provider,
+    HostPage = "wwwroot/index.html",
+};
+blazor.RootComponents.Add(new RootComponent
+{
+    Selector = "#app",
+    ComponentType = typeof(Main),
+});
+```
+
+Host page (`wwwroot/index.html`) should reference Blazor WebView scripts:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Avalonia Blazor Hybrid</title>
+</head>
+<body>
+  <div id="app">Loading...</div>
+  <script src="_framework/blazor.webview.js"></script>
+</body>
+</html>
+```
+
+A `chrome.webview` polyfill is injected automatically when HTML is served so Blazor IPC works with Avalonia's `invokeCSharpAction` bridge.
+
+## Prerequisites
+
+Same native WebView prerequisites as `Avalonia.Controls.WebView` (WebView2 Runtime, WebKitGTK, etc.).
+
+## Embedded `wwwroot` (no folder next to the exe)
+
+By default, static files are served from disk (`PhysicalFileProvider`). To ship without a physical `wwwroot` folder, override `CreateFileProvider` and embed the files:
+
+```xml
+<PropertyGroup>
+  <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+  <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" />
+  <Content Remove="wwwroot\**" />
+  <EmbeddedResource Include="wwwroot\**" />
+</ItemGroup>
+```
+
+```csharp
+protected override IFileProvider CreateFileProvider(string contentRootDir)
+{
+    var embedded = new ManifestEmbeddedFileProvider(typeof(Program).Assembly, "wwwroot");
+    return new CompositeFileProvider(embedded, base.CreateFileProvider(contentRootDir));
+}
+```
+
+Keep `HostPage` as `wwwroot/index.html` (logical path). `_framework/blazor.webview.js` is already embedded in `Microsoft.AspNetCore.Components.WebView` and does not need to be in your `wwwroot`.
+
+## AOT / trimming
+
+NativeAOT and aggressive trimming are not guaranteed with `Microsoft.AspNetCore.Components.WebView` in v1.

--- a/src/Avalonia.Controls.BlazorWebView/RootComponent.cs
+++ b/src/Avalonia.Controls.BlazorWebView/RootComponent.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Avalonia.Controls.BlazorWebView;
+
+/// <summary>
+/// Describes a root Blazor component hosted in a <see cref="BlazorWebView"/>.
+/// </summary>
+public sealed class RootComponent
+{
+    /// <summary>
+    /// CSS selector for the element that hosts the component (for example <c>#app</c>).
+    /// </summary>
+    public string Selector { get; set; } = "#app";
+
+    /// <summary>
+    /// The component type implementing <see cref="IComponent"/>.
+    /// </summary>
+    public Type? ComponentType { get; set; }
+
+    /// <summary>
+    /// Optional parameters for the root component.
+    /// </summary>
+    public IDictionary<string, object?>? Parameters { get; set; }
+
+    internal ParameterView ToParameterView()
+    {
+        if (Parameters is null || Parameters.Count == 0)
+            return ParameterView.Empty;
+        return ParameterView.FromDictionary(Parameters);
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Android/AndroidWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Android/AndroidWebViewAdapter.cs
@@ -509,68 +509,78 @@ internal class AndroidWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapter
                     }
                 };
 
-                // This flow is tricky. It's only possible to modify request headers for GET requests.
-                // We also don't want to block thread with sync Invoke if not necessary.
-                if (canEditHeaders)
-                {
-                    WebViewDispatcher.Invoke(() => webResourceRequested.Invoke(this, webResourceArgs));
+                // Sync invoke so SetResponse / header edits can be applied before returning.
+                WebViewDispatcher.Invoke(() => webResourceRequested.Invoke(this, webResourceArgs));
+                webResourceArgs.WaitForDeferralsAsync().GetAwaiter().GetResult();
 
-                    if (headersWrapper.HasChanges)
+                if (webResourceArgs is { Handled: true, Response: { } synthesized })
+                {
+                    var responseHeaders = new Dictionary<string, string>(synthesized.Headers);
+                    if (!responseHeaders.ContainsKey("Content-Type"))
+                        responseHeaders["Content-Type"] = synthesized.ContentType;
+
+                    var encoding = "UTF-8";
+                    var mimeType = synthesized.ContentType.Split(';')[0];
+                    return new WebResourceResponse(
+                        mimeType,
+                        encoding,
+                        synthesized.StatusCode,
+                        synthesized.ReasonPhrase,
+                        responseHeaders,
+                        synthesized.Content
+                    );
+                }
+
+                if (canEditHeaders && headersWrapper.HasChanges)
+                {
+                    try
                     {
+                        var url = new URL(request.Url.ToString());
+                        var connection = (HttpURLConnection)url.OpenConnection()!;
+
+                        foreach (var header in request.RequestHeaders!)
+                        {
+                            connection.SetRequestProperty(header.Key, header.Value);
+                        }
+
+                        connection.Connect();
+
+                        var encoding = connection.ContentEncoding ?? "UTF-8";
+                        var mimeType = connection.ContentType?.Split(';')[0] ?? "text/html";
+
+                        var responseHeaders = new Dictionary<string, string>();
+                        foreach (var entry in connection.HeaderFields ?? new Dictionary<string, IList<string>>())
+                        {
+                            if (entry is { Key: { } key, Value: { } value })
+                            {
+                                responseHeaders[key] = string.Join(",", value);
+                            }
+                        }
+
+                        System.IO.Stream? stream = null;
                         try
                         {
-                            var url = new URL(request.Url.ToString());
-                            var connection = (HttpURLConnection)url.OpenConnection()!;
-
-                            foreach (var header in request.RequestHeaders!)
-                            {
-                                connection.SetRequestProperty(header.Key, header.Value);
-                            }
-
-                            connection.Connect();
-
-                            var encoding = connection.ContentEncoding ?? "UTF-8";
-                            var mimeType = connection.ContentType?.Split(';')[0] ?? "text/html";
-
-                            var responseHeaders = new Dictionary<string, string>();
-                            foreach (var entry in connection.HeaderFields ?? new Dictionary<string, IList<string>>())
-                            {
-                                if (entry is { Key: { } key, Value: { } value })
-                                {
-                                    responseHeaders[key] = string.Join(",", value);
-                                }
-                            }
-
-                            System.IO.Stream? stream = null;
-                            try
-                            {
-                                stream = connection.InputStream;
-                            }
-                            catch
-                            {
-                                // Don't care.
-                            }
-
-                            return new WebResourceResponse(
-                                mimeType,
-                                encoding,
-                                (int)connection.ResponseCode,
-                                connection.ResponseMessage!,
-                                responseHeaders,
-                                stream
-                            );
+                            stream = connection.InputStream;
                         }
                         catch
                         {
                             // Don't care.
-                            return null;
                         }
+
+                        return new WebResourceResponse(
+                            mimeType,
+                            encoding,
+                            (int)connection.ResponseCode,
+                            connection.ResponseMessage!,
+                            responseHeaders,
+                            stream
+                        );
                     }
-                }
-                else
-                {
-                    // fallback to base.ShouldInterceptRequest
-                    WebViewDispatcher.InvokeAsync(() => webResourceRequested.Invoke(this, webResourceArgs));
+                    catch
+                    {
+                        // Don't care.
+                        return null;
+                    }
                 }
             }
 

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkInterop.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkInterop.cs
@@ -98,6 +98,48 @@ internal static unsafe partial class GtkInterop
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool g_main_context_is_owner(IntPtr context);
 
+    [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void webkit_web_context_register_uri_scheme(
+        IntPtr context,
+        string scheme,
+        IntPtr callback,
+        IntPtr userData,
+        IntPtr userDataDestroyFunc);
+
+    [DllImport(LibWebKit)]
+    internal static extern IntPtr webkit_uri_scheme_request_get_uri(IntPtr request);
+
+    [DllImport(LibWebKit)]
+    internal static extern IntPtr webkit_uri_scheme_request_get_http_method(IntPtr request);
+
+    [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void webkit_uri_scheme_request_finish(
+        IntPtr request,
+        IntPtr stream,
+        long streamLength,
+        string? mimeType);
+
+    [DllImport(LibWebKit)]
+    internal static extern void webkit_uri_scheme_request_finish_error(IntPtr request, IntPtr error);
+
+    [DllImport(LibWebKit)]
+    internal static extern IntPtr webkit_web_context_get_security_manager(IntPtr context);
+
+    [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void webkit_security_manager_register_uri_scheme_as_secure(IntPtr manager, string scheme);
+
+    [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void webkit_security_manager_register_uri_scheme_as_cors_enabled(IntPtr manager, string scheme);
+
+    [LibraryImport(LibWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void webkit_security_manager_register_uri_scheme_as_local(IntPtr manager, string scheme);
+
+    [DllImport(LibGLib)]
+    internal static extern IntPtr g_malloc(nuint nBytes);
+
+    [DllImport(LibGio)]
+    internal static extern IntPtr g_memory_input_stream_new_from_data(IntPtr data, nint len, IntPtr destroy);
+
     [DllImport(LibWebKit)]
     internal static extern IntPtr webkit_web_view_get_user_content_manager(IntPtr webView);
 

--- a/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Gtk/GtkWebViewAdapter.cs
@@ -45,6 +45,9 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
     private static readonly unsafe IntPtr s_resourceLoadStartedCallback =
         new((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, void>)&ResourceLoadStartedCallback);
 
+    private static readonly unsafe IntPtr s_uriSchemeRequestCallback =
+        new((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, void>)&UriSchemeRequestCallback);
+
     private readonly IntPtr _settings;
     private IntPtr _webViewHandle;
     private GtkSignal? _loadChangedSignal;
@@ -53,6 +56,7 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
     private GtkSignal? _focusOutSignal;
     private GtkSignal? _scriptMessageReceivedSignal;
     private GtkSignal? _resourceLoadStarted;
+    private GCHandle _schemeUserData;
     private Uri _source = WebViewHelper.EmptyPage;
 
     protected GtkWebViewAdapter(GtkWebViewEnvironmentRequestedEventArgs args)
@@ -62,7 +66,8 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             || args.BaseDataDirectory is { Length: >0}
             || args.BaseCacheDirectory is { Length: >0}
             || !args.SharedProcessModel
-            || args.DisableCache)
+            || args.DisableCache
+            || args.CustomSchemes.Count > 0)
         {
             if (args.EphemeralDataManager)
             {
@@ -104,6 +109,26 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
         else
         {
             context = webkit_web_context_get_default();
+        }
+
+        if (args.CustomSchemes.Count > 0)
+        {
+            _schemeUserData = GCHandle.Alloc(this);
+            var userData = GCHandle.ToIntPtr(_schemeUserData);
+            var securityManager = webkit_web_context_get_security_manager(context);
+            foreach (var scheme in args.CustomSchemes)
+            {
+                if (string.IsNullOrWhiteSpace(scheme))
+                    continue;
+                webkit_web_context_register_uri_scheme(
+                    context, scheme, s_uriSchemeRequestCallback, userData, IntPtr.Zero);
+                if (securityManager != IntPtr.Zero)
+                {
+                    webkit_security_manager_register_uri_scheme_as_secure(securityManager, scheme);
+                    webkit_security_manager_register_uri_scheme_as_cors_enabled(securityManager, scheme);
+                    webkit_security_manager_register_uri_scheme_as_local(securityManager, scheme);
+                }
+            }
         }
 
         _webViewHandle = webkit_web_view_new_with_context(context);
@@ -530,6 +555,80 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void UriSchemeRequestCallback(IntPtr request, IntPtr userData)
+    {
+        if (userData == IntPtr.Zero)
+            return;
+
+        GtkWebViewAdapter? adapter = null;
+        try
+        {
+            adapter = GCHandle.FromIntPtr(userData).Target as GtkWebViewAdapter;
+        }
+        catch
+        {
+            return;
+        }
+
+        if (adapter is null)
+            return;
+
+        var uriPtr = webkit_uri_scheme_request_get_uri(request);
+        var uriString = Marshal.PtrToStringUTF8(uriPtr);
+        if (uriString is null || !Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+            return;
+
+        var methodPtr = webkit_uri_scheme_request_get_http_method(request);
+        var method = Marshal.PtrToStringUTF8(methodPtr) ?? "GET";
+
+        var args = new WebResourceRequestedEventArgs
+        {
+            Request = new WebViewWebResourceRequest
+            {
+                Method = new HttpMethod(method),
+                Uri = uri,
+                Headers = new NativeHeadersCollection(DictionaryNativeHttpRequestHeaders.ImmutableInstance)
+            }
+        };
+
+        WebViewDispatcher.Invoke(() =>
+        {
+            adapter.WebResourceRequested?.Invoke(adapter, args);
+            args.WaitForDeferralsAsync().GetAwaiter().GetResult();
+
+            if (args is { Handled: true, Response: { } response })
+            {
+                FinishUriSchemeRequest(request, response);
+            }
+        });
+    }
+
+    private static void FinishUriSchemeRequest(IntPtr request, WebViewWebResourceResponse response)
+    {
+        using var ms = new MemoryStream();
+        response.Content.CopyTo(ms);
+        var bytes = ms.ToArray();
+        var data = g_malloc((nuint)bytes.Length);
+        if (bytes.Length > 0)
+            Marshal.Copy(bytes, 0, data, bytes.Length);
+
+        var stream = g_memory_input_stream_new_from_data(data, bytes.Length, GetGFreePointer());
+        webkit_uri_scheme_request_finish(request, stream, bytes.Length, response.ContentType);
+        g_object_unref(stream);
+    }
+
+    private static IntPtr GetGFreePointer()
+    {
+        if (NativeLibrary.TryLoad("libglib-2.0.so.0", out var lib) ||
+            NativeLibrary.TryLoad("libglib-2.0.so", out lib))
+        {
+            if (NativeLibrary.TryGetExport(lib, "g_free", out var free))
+                return free;
+        }
+        return IntPtr.Zero;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void ResourceLoadStartedCallback(IntPtr widget, IntPtr resource, IntPtr request, IntPtr data)
     {
         if (!GtkSignal.TryGetState<GtkWebViewAdapter>(data, out var adapter)
@@ -614,6 +713,8 @@ internal abstract class GtkWebViewAdapter : IWebViewAdapterWithFocus, IGtkWebVie
             Interlocked.Exchange(ref _focusOutSignal, null)?.Dispose();
             Interlocked.Exchange(ref _scriptMessageReceivedSignal, null)?.Dispose();
             Interlocked.Exchange(ref _resourceLoadStarted, null)?.Dispose();
+            if (_schemeUserData.IsAllocated)
+                _schemeUserData.Free();
         }
 
         var webView = Interlocked.Exchange(ref _webViewHandle, IntPtr.Zero);

--- a/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/IWebViewAdapter.cs
@@ -44,6 +44,14 @@ public abstract class WebViewEnvironmentRequestedEventArgs : EventArgs
     public bool EnableDevTools { get; set; }
 
     /// <summary>
+    /// Custom URI schemes to register with the underlying web engine (for example <c>app</c>).
+    /// Must be set during the <c>EnvironmentRequested</c> event before the adapter is created.
+    /// Required on WebKit-based platforms (macOS, iOS, Linux) to serve local content; Windows WebView2
+    /// typically serves Hybrid content over <c>http://0.0.0.0/</c> instead.
+    /// </summary>
+    public IList<string> CustomSchemes { get; } = new List<string>();
+
+    /// <summary>
     /// Gets a deferral that can be used to delay the completion of the event.
     /// </summary>
     public IDisposable GetDeferral() => _deferralManager.GetDeferral();
@@ -54,9 +62,66 @@ public sealed class WebMessageReceivedEventArgs : EventArgs
     public string? Body { get; init; }
 }
 
+/// <summary>
+/// Response payload supplied via <see cref="WebResourceRequestedEventArgs.SetResponse"/>.
+/// </summary>
+public sealed class WebViewWebResourceResponse
+{
+    public required Stream Content { get; init; }
+    public required int StatusCode { get; init; }
+    public required string ReasonPhrase { get; init; }
+    public required string ContentType { get; init; }
+    public IReadOnlyDictionary<string, string> Headers { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}
+
 public sealed class WebResourceRequestedEventArgs : EventArgs
 {
+    private readonly DeferralManager _deferralManager = new();
+    private WebViewWebResourceResponse? _response;
+
     public required WebViewWebResourceRequest Request { get; init; }
+
+    /// <summary>
+    /// True after <see cref="SetResponse"/> has been called.
+    /// </summary>
+    public bool Handled { get; private set; }
+
+    /// <summary>
+    /// Fulfills the request with app-local bytes. Platforms that support response synthesis
+    /// will return this content instead of performing a network load.
+    /// </summary>
+    public void SetResponse(
+        Stream content,
+        int statusCode,
+        string reasonPhrase,
+        string contentType,
+        IReadOnlyDictionary<string, string>? headers = null)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(reasonPhrase);
+        ArgumentNullException.ThrowIfNull(contentType);
+
+        _response = new WebViewWebResourceResponse
+        {
+            Content = content,
+            StatusCode = statusCode,
+            ReasonPhrase = reasonPhrase,
+            ContentType = contentType,
+            Headers = headers ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+        Handled = true;
+    }
+
+    /// <summary>
+    /// Gets a deferral that delays completion of the resource request until disposed,
+    /// allowing asynchronous content providers to call <see cref="SetResponse"/> later.
+    /// </summary>
+    public IDisposable GetDeferral() => _deferralManager.GetDeferral();
+
+    internal WebViewWebResourceResponse? Response => _response;
+
+    internal Task WaitForDeferralsAsync() => _deferralManager.WaitForDeferralsAsync();
 }
 
 public abstract class WebViewWebRequestHeaders : IReadOnlyDictionary<string, string>
@@ -299,12 +364,16 @@ internal interface IWebView
     event EventHandler<WebMessageReceivedEventArgs> WebMessageReceived;
 
     /// <summary>
-    /// Fires when the WebView is performing a URL request to a matching URL.
+    /// Fires when the WebView is performing a URL request to a matching URL,
+    /// or when a registered custom URI scheme is requested.
     /// </summary>
     /// <remarks>
     /// Arguments include request information, and headers dictionary.
     /// Headers dictionary can be readonly depending on the request or platform.
     /// Always check result of the `TrySet` and `TryRemove` methods.
+    /// Call <see cref="WebResourceRequestedEventArgs.SetResponse"/> to fulfill the request with local content
+    /// (required for offline / Hybrid apps). Use <see cref="WebViewEnvironmentRequestedEventArgs.CustomSchemes"/>
+    /// to register schemes such as <c>app</c> on WebKit-based platforms.
     /// </remarks>
     event EventHandler<WebResourceRequestedEventArgs> WebResourceRequested;
     

--- a/src/Avalonia.Controls.WebView.Core/Linux/Interop/WpeInterop.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/Interop/WpeInterop.cs
@@ -186,6 +186,44 @@ internal static unsafe partial class WpeInterop
     public static partial IntPtr webkit_uri_request_get_uri(IntPtr request);
 
     [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_web_view_get_context(IntPtr webView);
+
+    [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_web_context_get_default();
+
+    [LibraryImport(LibWpeWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial void webkit_web_context_register_uri_scheme(
+        IntPtr context, string scheme, IntPtr callback, IntPtr userData, IntPtr destroyNotify);
+
+    [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_uri_scheme_request_get_uri(IntPtr request);
+
+    [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_uri_scheme_request_get_http_method(IntPtr request);
+
+    [LibraryImport(LibWpeWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial void webkit_uri_scheme_request_finish(
+        IntPtr request, IntPtr stream, long streamLength, string? mimeType);
+
+    [LibraryImport(LibWpeWebKit)]
+    public static partial IntPtr webkit_web_context_get_security_manager(IntPtr context);
+
+    [LibraryImport(LibWpeWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial void webkit_security_manager_register_uri_scheme_as_secure(IntPtr manager, string scheme);
+
+    [LibraryImport(LibWpeWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial void webkit_security_manager_register_uri_scheme_as_cors_enabled(IntPtr manager, string scheme);
+
+    [LibraryImport(LibWpeWebKit, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial void webkit_security_manager_register_uri_scheme_as_local(IntPtr manager, string scheme);
+
+    [LibraryImport(LibGLib)]
+    public static partial IntPtr g_malloc(nuint nBytes);
+
+    [LibraryImport("libgio-2.0.so.0")]
+    public static partial IntPtr g_memory_input_stream_new_from_data(IntPtr data, nint len, IntPtr destroy);
+
+    [LibraryImport(LibWpeWebKit)]
     public static partial void webkit_policy_decision_ignore(IntPtr decision);
 
     [LibraryImport(LibWpeWebKit)]

--- a/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Linux/WpeWebViewAdapter.cs
@@ -52,6 +52,7 @@ internal sealed unsafe class WpeWebViewAdapter
     private readonly GSignalCreateCallback _createCallback;
     private readonly GSignalScriptMessageCallback _scriptMessageCallback;
     private readonly GSignalLoadFailedCallback _loadFailedCallback;
+    private readonly UriSchemeRequestCallback _uriSchemeCallback;
     private GCHandle _selfHandle;
 
     private WpeWebViewAdapter()
@@ -63,6 +64,7 @@ internal sealed unsafe class WpeWebViewAdapter
         _createCallback = OnCreate;
         _scriptMessageCallback = OnScriptMessageReceived;
         _loadFailedCallback = OnLoadFailed;
+        _uriSchemeCallback = OnUriSchemeRequest;
     }
 
     // Unmanaged callback signatures
@@ -83,6 +85,9 @@ internal sealed unsafe class WpeWebViewAdapter
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int GSignalLoadFailedCallback(IntPtr webView, int loadEvent, IntPtr failingUri, IntPtr error, IntPtr userData);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void UriSchemeRequestCallback(IntPtr request, IntPtr userData);
 
     public static bool IsAvailable() => s_isAvailable.Value;
 
@@ -250,6 +255,8 @@ internal sealed unsafe class WpeWebViewAdapter
         _webView = WpeInterop.g_object_new_with_properties(webViewType, 3, keys, values);
         if (_webView == IntPtr.Zero)
             throw new InvalidOperationException("webkit_web_view_new failed.");
+
+        RegisterCustomSchemes(args, selfPtr);
 
         var viewContentManager = WpeInterop.webkit_web_view_get_user_content_manager(_webView);
         if (viewContentManager != IntPtr.Zero && viewContentManager != _userContentManager)
@@ -973,6 +980,85 @@ internal sealed unsafe class WpeWebViewAdapter
         }
 
         tcs.TrySetResult(cookies);
+    }
+
+    private void RegisterCustomSchemes(LinuxWpeWebViewEnvironmentRequestedEventArgs args, IntPtr selfPtr)
+    {
+        if (args.CustomSchemes.Count == 0)
+            return;
+
+        var context = WpeInterop.webkit_web_view_get_context(_webView);
+        if (context == IntPtr.Zero)
+            context = WpeInterop.webkit_web_context_get_default();
+        if (context == IntPtr.Zero)
+            return;
+
+        var callbackPtr = Marshal.GetFunctionPointerForDelegate(_uriSchemeCallback);
+        var securityManager = WpeInterop.webkit_web_context_get_security_manager(context);
+        foreach (var scheme in args.CustomSchemes)
+        {
+            if (string.IsNullOrWhiteSpace(scheme))
+                continue;
+            WpeInterop.webkit_web_context_register_uri_scheme(
+                context, scheme, callbackPtr, selfPtr, IntPtr.Zero);
+            if (securityManager != IntPtr.Zero)
+            {
+                WpeInterop.webkit_security_manager_register_uri_scheme_as_secure(securityManager, scheme);
+                WpeInterop.webkit_security_manager_register_uri_scheme_as_cors_enabled(securityManager, scheme);
+                WpeInterop.webkit_security_manager_register_uri_scheme_as_local(securityManager, scheme);
+            }
+        }
+    }
+
+    private void OnUriSchemeRequest(IntPtr request, IntPtr userData)
+    {
+        if (!_selfHandle.IsAllocated || GCHandle.FromIntPtr(userData).Target is not WpeWebViewAdapter adapter)
+            return;
+
+        var uriPtr = WpeInterop.webkit_uri_scheme_request_get_uri(request);
+        var uriString = Marshal.PtrToStringUTF8(uriPtr);
+        if (uriString is null || !Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+            return;
+
+        var methodPtr = WpeInterop.webkit_uri_scheme_request_get_http_method(request);
+        var method = Marshal.PtrToStringUTF8(methodPtr) ?? "GET";
+
+        var args = new WebResourceRequestedEventArgs
+        {
+            Request = new WebViewWebResourceRequest
+            {
+                Method = new System.Net.Http.HttpMethod(method),
+                Uri = uri,
+                Headers = new Utils.NativeHeadersCollection(Utils.DictionaryNativeHttpRequestHeaders.ImmutableInstance)
+            }
+        };
+
+        Dispatcher.UIThread.Invoke(() =>
+        {
+            adapter.WebResourceRequested?.Invoke(adapter, args);
+            args.WaitForDeferralsAsync().GetAwaiter().GetResult();
+
+            if (args is { Handled: true, Response: { } response })
+                FinishUriSchemeRequest(request, response);
+        });
+    }
+
+    private static void FinishUriSchemeRequest(IntPtr request, WebViewWebResourceResponse response)
+    {
+        using var ms = new System.IO.MemoryStream();
+        response.Content.CopyTo(ms);
+        var bytes = ms.ToArray();
+        var data = WpeInterop.g_malloc((nuint)bytes.Length);
+        if (bytes.Length > 0)
+            Marshal.Copy(bytes, 0, data, bytes.Length);
+
+        IntPtr destroyFree = IntPtr.Zero;
+        if (NativeLibrary.TryLoad("libglib-2.0.so.0", out var glib))
+            NativeLibrary.TryGetExport(glib, "g_free", out destroyFree);
+
+        var stream = WpeInterop.g_memory_input_stream_new_from_data(data, bytes.Length, destroyFree);
+        WpeInterop.webkit_uri_scheme_request_finish(request, stream, bytes.Length, response.ContentType);
+        WpeInterop.g_object_unref(stream);
     }
 
     // --- ILinuxWpePlatformHandle ---

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/Libobjc.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/Libobjc.cs
@@ -96,6 +96,10 @@ internal static unsafe partial class Libobjc
     [DllImport(libobjc, EntryPoint = "objc_msgSend")]
     public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector, IntPtr param1, IntPtr param2, UIntPtr param3);
     [DllImport(libobjc, EntryPoint = "objc_msgSend")]
+    public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector, IntPtr param1, UIntPtr param2);
+    [DllImport(libobjc, EntryPoint = "objc_msgSend")]
+    public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector, IntPtr param1, nint param2, IntPtr param3, IntPtr param4);
+    [DllImport(libobjc, EntryPoint = "objc_msgSend")]
     public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector, IntPtr param1, IntPtr param2, IntPtr param3, int param4);
     [DllImport(libobjc, EntryPoint = "objc_msgSend")]
     public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector, IntPtr param1, IntPtr param2, int param3);

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSData.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSData.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Avalonia.Controls.Macios.Interop;
+
+internal sealed class NSData : NSObject
+{
+    private static readonly IntPtr s_class = Libobjc.objc_getClass("NSData");
+    private static readonly IntPtr s_dataWithBytesLength = Libobjc.sel_getUid("dataWithBytes:length:");
+
+    private NSData(IntPtr handle, bool owns) : base(handle, owns)
+    {
+    }
+
+    public static unsafe NSData FromBytes(ReadOnlySpan<byte> bytes)
+    {
+        fixed (byte* ptr = bytes)
+        {
+            var handle = Libobjc.intptr_objc_msgSend(
+                s_class,
+                s_dataWithBytesLength,
+                (IntPtr)ptr,
+                new UIntPtr((uint)bytes.Length));
+            return new NSData(handle, true);
+        }
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSHTTPURLResponse.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/NSHTTPURLResponse.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Controls.Macios.Interop;
+
+internal sealed class NSHTTPURLResponse : NSObject
+{
+    private static readonly IntPtr s_class = Libobjc.objc_getClass("NSHTTPURLResponse");
+    private static readonly IntPtr s_initWithURL =
+        Libobjc.sel_getUid("initWithURL:statusCode:HTTPVersion:headerFields:");
+
+    private NSHTTPURLResponse(IntPtr handle, bool owns) : base(handle, owns)
+    {
+    }
+
+    public static NSHTTPURLResponse Create(
+        NSUrl url,
+        int statusCode,
+        string httpVersion,
+        IReadOnlyDictionary<string, string> headers)
+    {
+        var keys = new List<NSObject>(headers.Count);
+        var values = new List<NSObject>(headers.Count);
+        foreach (var pair in headers)
+        {
+            keys.Add(NSString.Create(pair.Key));
+            values.Add(NSString.Create(pair.Value));
+        }
+
+        using var headerDict = NSDictionary.WithObjects(values, keys, (uint)keys.Count);
+        using var version = NSString.Create(httpVersion);
+
+        var allocated = Libobjc.intptr_objc_msgSend(s_class, Libobjc.sel_getUid("alloc"));
+        var handle = Libobjc.intptr_objc_msgSend(
+            allocated,
+            s_initWithURL,
+            url.Handle,
+            (nint)statusCode,
+            version.Handle,
+            headerDict.Handle);
+
+        return new NSHTTPURLResponse(handle, true);
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKURLSchemeHandler.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKURLSchemeHandler.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Avalonia.Controls.Macios.Interop;
+
+namespace Avalonia.Controls.Macios.Interop.WebKit;
+
+/// <summary>
+/// Managed WKURLSchemeHandler that raises events for custom-scheme requests.
+/// </summary>
+internal unsafe class WKURLSchemeHandler : NSManagedObjectBase
+{
+    private static readonly IntPtr s_class;
+    private static readonly IntPtr s_taskRequest = Libobjc.sel_getUid("request");
+    private static readonly IntPtr s_didReceiveResponse = Libobjc.sel_getUid("didReceiveResponse:");
+    private static readonly IntPtr s_didReceiveData = Libobjc.sel_getUid("didReceiveData:");
+    private static readonly IntPtr s_didFinish = Libobjc.sel_getUid("didFinish");
+    private static readonly IntPtr s_didFailWithError = Libobjc.sel_getUid("didFailWithError:");
+
+    private static readonly delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, void>
+        s_startURLSchemeTask = &OnStartURLSchemeTask;
+    private static readonly delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, void>
+        s_stopURLSchemeTask = &OnStopURLSchemeTask;
+
+    static WKURLSchemeHandler()
+    {
+        var delegateClass = AllocateClassPair("ManagedWKURLSchemeHandler");
+
+        if (Libobjc.objc_getProtocol("WKURLSchemeHandler") is var protocol and > 0)
+            AddProtocol(delegateClass, protocol);
+
+        AddMethod(delegateClass, Libobjc.sel_getUid("webView:startURLSchemeTask:"),
+            new IntPtr(s_startURLSchemeTask), "v@:@@");
+        AddMethod(delegateClass, Libobjc.sel_getUid("webView:stopURLSchemeTask:"),
+            new IntPtr(s_stopURLSchemeTask), "v@:@@");
+
+        RegisterManagedMembers(delegateClass);
+        Libobjc.objc_registerClassPair(delegateClass);
+        s_class = delegateClass;
+    }
+
+    public WKURLSchemeHandler() : base(s_class)
+    {
+        Init();
+    }
+
+    public event EventHandler<URLSchemeTaskEventArgs>? StartURLSchemeTask;
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnStartURLSchemeTask(IntPtr self, IntPtr sel, IntPtr webView, IntPtr task)
+    {
+        var managed = ReadManagedSelf<WKURLSchemeHandler>(self);
+        if (managed is null)
+            return;
+
+        var requestPtr = Libobjc.intptr_objc_msgSend(task, s_taskRequest);
+        managed.StartURLSchemeTask?.Invoke(managed, new URLSchemeTaskEventArgs(task, requestPtr));
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnStopURLSchemeTask(IntPtr self, IntPtr sel, IntPtr webView, IntPtr task)
+    {
+        // No-op: callers finish synchronously or via managed deferral on Start.
+    }
+
+    public static void CompleteTask(IntPtr task, NSHTTPURLResponse response, NSData data)
+    {
+        Libobjc.void_objc_msgSend(task, s_didReceiveResponse, response.Handle);
+        Libobjc.void_objc_msgSend(task, s_didReceiveData, data.Handle);
+        Libobjc.void_objc_msgSend(task, s_didFinish);
+    }
+
+    public static void FailTask(IntPtr task, IntPtr error)
+    {
+        Libobjc.void_objc_msgSend(task, s_didFailWithError, error);
+    }
+
+    public sealed class URLSchemeTaskEventArgs(IntPtr task, IntPtr request) : EventArgs
+    {
+        public IntPtr Task { get; } = task;
+        public IntPtr Request { get; } = request;
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKWebViewConfiguration.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/Interop/WebKit/WKWebViewConfiguration.cs
@@ -19,6 +19,7 @@ internal class WKWebViewConfiguration : NSObject
     private static readonly IntPtr s_userContentController = Libobjc.sel_getUid("userContentController");
     private static readonly IntPtr s_contentAddScriptMessageHandler = Libobjc.sel_getUid("addScriptMessageHandler:name:");
     private static readonly IntPtr s_contentRemoveScriptMessageHandlerForName = Libobjc.sel_getUid("removeScriptMessageHandlerForName:");
+    private static readonly IntPtr s_setURLSchemeHandler = Libobjc.sel_getUid("setURLSchemeHandler:forURLScheme:");
 
     public WKWebViewConfiguration() : base(s_class)
     {
@@ -69,6 +70,11 @@ internal class WKWebViewConfiguration : NSObject
     {
         var controllerPtr = Libobjc.intptr_objc_msgSend(Handle, s_userContentController);
         Libobjc.void_objc_msgSend(controllerPtr, s_contentRemoveScriptMessageHandlerForName, handlerName.Handle);
+    }
+
+    public void SetURLSchemeHandler(WKURLSchemeHandler handler, NSString scheme)
+    {
+        Libobjc.void_objc_msgSend(Handle, s_setURLSchemeHandler, handler.Handle, scheme.Handle);
     }
 
     public WKPreferences Preferences { get; }

--- a/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Macios/MaciosWebViewAdapter.cs
@@ -27,6 +27,7 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
     private readonly WKWebView _webView;
     private readonly WKNavigationDelegate _navDelegate;
     private readonly WKScriptMessageHandler _scriptHandler;
+    private readonly WKURLSchemeHandler? _urlSchemeHandler;
 
     static MaciosWebViewAdapter()
     {
@@ -42,6 +43,19 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
         _scriptHandlerMessageNameNative = NSString.Create(_scriptHandlerMessageName);
         _config = new WKWebViewConfiguration { JavaScriptEnabled = true };
         _config.AddScriptMessageHandler(_scriptHandler, _scriptHandlerMessageNameNative);
+
+        if (options.CustomSchemes.Count > 0)
+        {
+            _urlSchemeHandler = new WKURLSchemeHandler();
+            _urlSchemeHandler.StartURLSchemeTask += OnUrlSchemeHandlerOnStartURLSchemeTask;
+            foreach (var scheme in options.CustomSchemes)
+            {
+                if (string.IsNullOrWhiteSpace(scheme))
+                    continue;
+                using var schemeStr = NSString.Create(scheme);
+                _config.SetURLSchemeHandler(_urlSchemeHandler, schemeStr);
+            }
+        }
 
         if (options.ApplicationNameForUserAgent is not null)
         {
@@ -253,6 +267,57 @@ internal class MaciosWebViewAdapter : IWebViewAdapterWithFocus, IWebViewAdapterW
             await WKWebView.PtrResultToString(args.Body, state);
             var str = await tcs.Task;
             WebMessageReceived?.Invoke(this, new WebMessageReceivedEventArgs { Body = str });
+        }
+    }
+
+    private async void OnUrlSchemeHandlerOnStartURLSchemeTask(object? sender, WKURLSchemeHandler.URLSchemeTaskEventArgs e)
+    {
+        var request = NSURLRequest.FromHandle(e.Request);
+        using var nsUrl = request.Url;
+        if (!Uri.TryCreate(nsUrl.AbsoluteString, UriKind.Absolute, out var uri))
+        {
+            WKURLSchemeHandler.FailTask(e.Task, IntPtr.Zero);
+            return;
+        }
+
+        var headers = new WKWebKitNativeHttpRequestHeaders(request, true);
+        var headersWrapper = new NativeHeadersCollection(headers);
+        var webResourceArgs = new WebResourceRequestedEventArgs
+        {
+            Request = new WebViewWebResourceRequest
+            {
+                Method = new HttpMethod(request.HTTPMethod.GetString() ?? "GET"),
+                Uri = uri,
+                Headers = headersWrapper,
+            }
+        };
+
+        try
+        {
+            WebResourceRequested?.Invoke(this, webResourceArgs);
+            await webResourceArgs.WaitForDeferralsAsync().ConfigureAwait(true);
+
+            if (webResourceArgs is { Handled: true, Response: { } response })
+            {
+                var headerDict = new Dictionary<string, string>(response.Headers);
+                if (!headerDict.ContainsKey("Content-Type"))
+                    headerDict["Content-Type"] = response.ContentType;
+
+                using var httpResponse = NSHTTPURLResponse.Create(nsUrl, response.StatusCode, "HTTP/1.1", headerDict);
+                using var ms = new MemoryStream();
+                await response.Content.CopyToAsync(ms).ConfigureAwait(true);
+                using var data = NSData.FromBytes(ms.ToArray());
+                WKURLSchemeHandler.CompleteTask(e.Task, httpResponse, data);
+            }
+            else
+            {
+                // No handler response — fail the scheme task.
+                WKURLSchemeHandler.FailTask(e.Task, IntPtr.Zero);
+            }
+        }
+        finally
+        {
+            headersWrapper.Dispose();
         }
     }
 

--- a/src/Avalonia.Controls.WebView.Core/Win/Interop/ComStreamFromManagedStream.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/Interop/ComStreamFromManagedStream.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using System.Runtime.Versioning;
+
+namespace Avalonia.Controls.Win.Interop;
+
+/// <summary>
+/// Exposes a managed <see cref="Stream"/> as a COM <see cref="IComStream"/> for WebView2 APIs.
+/// </summary>
+[GeneratedComClass]
+[SupportedOSPlatform("windows6.1")]
+internal partial class ComStreamFromManagedStream(Stream stream) : IComStream
+{
+    private Stream? _stream = stream;
+
+    public unsafe int Read(byte* pv, uint cb, uint* pcbRead)
+    {
+        if (_stream is null)
+            return unchecked((int)0x80004005); // E_FAIL
+
+        var buffer = new byte[cb];
+        var read = _stream.Read(buffer, 0, (int)cb);
+        if (read > 0)
+            Marshal.Copy(buffer, 0, (IntPtr)pv, read);
+        if (pcbRead != null)
+            *pcbRead = (uint)read;
+        return 0;
+    }
+
+    public unsafe int Write(byte* pv, uint cb, uint* pcbWritten)
+    {
+        if (_stream is null)
+            return unchecked((int)0x80004005);
+
+        var buffer = new byte[cb];
+        Marshal.Copy((IntPtr)pv, buffer, 0, (int)cb);
+        _stream.Write(buffer, 0, (int)cb);
+        if (pcbWritten != null)
+            *pcbWritten = cb;
+        return 0;
+    }
+
+    public int Seek(long dlibMove, int dwOrigin, out ulong plibNewPosition)
+    {
+        plibNewPosition = 0;
+        if (_stream is null)
+            return unchecked((int)0x80004005);
+
+        plibNewPosition = (ulong)_stream.Seek(dlibMove, (SeekOrigin)dwOrigin);
+        return 0;
+    }
+
+    public int SetSize(ulong libNewSize)
+    {
+        if (_stream is null)
+            return unchecked((int)0x80004005);
+        _stream.SetLength((long)libNewSize);
+        return 0;
+    }
+
+    public int CopyTo(IComStream pstm, ulong cb, out ulong pcbRead, out ulong pcbWritten)
+    {
+        pcbRead = 0;
+        pcbWritten = 0;
+        return unchecked((int)0x80004001); // E_NOTIMPL
+    }
+
+    public int Commit(int grfCommitFlags)
+    {
+        _stream?.Flush();
+        return 0;
+    }
+
+    public int Revert() => 0;
+
+    public int LockRegion(ulong libOffset, ulong cb, int dwLockType) =>
+        unchecked((int)0x80004001);
+
+    public int UnlockRegion(ulong libOffset, ulong cb, int dwLockType) =>
+        unchecked((int)0x80004001);
+
+    public int Stat(IntPtr pstatstg, int grfStatFlag) =>
+        unchecked((int)0x80004001);
+
+    public int Clone(out IComStream ppstm)
+    {
+        ppstm = null!;
+        return unchecked((int)0x80004001);
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/Interop/ICoreWebView2Deferral.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/Interop/ICoreWebView2Deferral.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Avalonia.Controls.Win.WebView2.Interop;
+
+[GeneratedComInterface(Options = ComInterfaceOptions.ComObjectWrapper)]
+[Guid("C10E7F7B-B585-46F0-A623-8BEFBF3E4EE0")]
+internal partial interface ICoreWebView2Deferral
+{
+    void Complete();
+}

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebResourceResponseHelper.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebResourceResponseHelper.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+using Avalonia.Controls.Win.WebView2.Interop;
+
+namespace Avalonia.Controls.Win.WebView2;
+
+[SupportedOSPlatform("windows6.1")]
+internal static unsafe class WebResourceResponseHelper
+{
+    [DllImport("shlwapi.dll", ExactSpelling = true)]
+    private static extern IntPtr SHCreateMemStream(byte* pInit, uint cbInit);
+
+    public static IntPtr CreateNativeResponse(
+        ICoreWebView2Environment environment,
+        WebViewWebResourceResponse response)
+    {
+        var headers = BuildHeaderString(response);
+        using var ms = response.Content as MemoryStream ?? CopyToMemoryStream(response.Content);
+        var bytes = ms.ToArray();
+        IntPtr nativeStream;
+        if (bytes.Length == 0)
+        {
+            nativeStream = SHCreateMemStream(null, 0);
+        }
+        else
+        {
+            fixed (byte* ptr = bytes)
+            {
+                nativeStream = SHCreateMemStream(ptr, (uint)bytes.Length);
+            }
+        }
+
+        if (nativeStream == IntPtr.Zero)
+            throw new InvalidOperationException("SHCreateMemStream failed.");
+
+        try
+        {
+            return environment.CreateWebResourceResponse(
+                nativeStream,
+                response.StatusCode,
+                response.ReasonPhrase,
+                headers);
+        }
+        finally
+        {
+            Marshal.Release(nativeStream);
+        }
+    }
+
+    private static string BuildHeaderString(WebViewWebResourceResponse response)
+    {
+        var sb = new StringBuilder();
+        var hasContentType = false;
+        var hasContentLength = false;
+        foreach (var pair in response.Headers)
+        {
+            if (pair.Key.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
+                hasContentType = true;
+            if (pair.Key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                hasContentLength = true;
+            sb.Append(pair.Key).Append(": ").Append(pair.Value).Append("\r\n");
+        }
+
+        if (!hasContentType)
+            sb.Append("Content-Type: ").Append(response.ContentType).Append("\r\n");
+
+        if (!hasContentLength && response.Content.CanSeek)
+            sb.Append("Content-Length: ").Append(response.Content.Length).Append("\r\n");
+
+        return sb.ToString();
+    }
+
+    private static MemoryStream CopyToMemoryStream(Stream source)
+    {
+        if (source.CanSeek)
+            source.Position = 0;
+        var ms = new MemoryStream();
+        source.CopyTo(ms);
+        ms.Position = 0;
+        return ms;
+    }
+}

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebView2BaseAdapter.cs
@@ -284,6 +284,9 @@ internal abstract partial class WebView2BaseAdapter(ICoreWebView2Controller cont
         public const int EInvalidState = unchecked((int)0x8007139F);
     }
 
+    internal ICoreWebView2Environment? TryGetEnvironment() =>
+        TryGetWebView2() is ICoreWebView2_2 webView2 ? webView2.Environment() : null;
+
     internal EventHandler<WebViewNavigationStartingEventArgs>? GetNavigationStarted() => NavigationStarted;
     internal EventHandler<WebViewNavigationCompletedEventArgs>? GetNavigationCompleted() => NavigationCompleted;
     internal EventHandler<WebMessageReceivedEventArgs>? GetWebMessageReceived() => WebMessageReceived;

--- a/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebViewCallbacks.cs
+++ b/src/Avalonia.Controls.WebView.Core/Win/WebView2/WebViewCallbacks.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using System.Runtime.Versioning;
 using Avalonia.Controls.Utils;
@@ -83,9 +84,53 @@ internal partial class WebViewCallbacks(WeakReference<WebView2BaseAdapter> weakA
                 };
 
                 var args = new WebResourceRequestedEventArgs { Request = request };
-                handler.Invoke(adapter, args);
-                headersWrapper.Dispose();
+                var nativeDeferral = (ICoreWebView2Deferral?)null;
+                try
+                {
+                    // Take a native deferral so async SetResponse (via GetDeferral) can complete later.
+                    var deferralPtr = e.GetDeferral();
+                    if (deferralPtr != IntPtr.Zero)
+                    {
+                        unsafe
+                        {
+                            nativeDeferral = ComInterfaceMarshaller<ICoreWebView2Deferral>
+                                .ConvertToManaged(deferralPtr.ToPointer());
+                        }
+                    }
+
+                    handler.Invoke(adapter, args);
+
+                    ApplyResponseAfterDeferrals(adapter, e, args, nativeDeferral);
+                }
+                finally
+                {
+                    headersWrapper.Dispose();
+                }
             }
+        }
+    }
+
+    private static async void ApplyResponseAfterDeferrals(
+        WebView2BaseAdapter adapter,
+        ICoreWebView2WebResourceRequestedEventArgs e,
+        WebResourceRequestedEventArgs args,
+        ICoreWebView2Deferral? nativeDeferral)
+    {
+        try
+        {
+            await args.WaitForDeferralsAsync().ConfigureAwait(true);
+
+            if (args is { Handled: true, Response: { } response }
+                && adapter.TryGetEnvironment() is { } environment)
+            {
+                var nativeResponse = WebResourceResponseHelper.CreateNativeResponse(environment, response);
+                if (nativeResponse != IntPtr.Zero)
+                    e.SetResponse(nativeResponse);
+            }
+        }
+        finally
+        {
+            nativeDeferral?.Complete();
         }
     }
 

--- a/src/Avalonia.Controls.WebView/CHANGELOG.md
+++ b/src/Avalonia.Controls.WebView/CHANGELOG.md
@@ -1,1 +1,5 @@
-See https://github.com/AvaloniaUI/Avalonia.Controls.WebView/releases
+## Unreleased
+
+### Added
+- Local content serving: `WebResourceRequestedEventArgs.SetResponse` / `GetDeferral` / `Handled`, plus `WebViewEnvironmentRequestedEventArgs.CustomSchemes` for custom URI schemes (WebKit / Android / WebView2).
+- Separate package `Avalonia.Controls.BlazorWebView` for Blazor Hybrid over `NativeWebView`.

--- a/src/Avalonia.Controls.WebView/README.md
+++ b/src/Avalonia.Controls.WebView/README.md
@@ -9,8 +9,38 @@ The Avalonia WebView component provides native web browser functionality for you
 - **AOT Compatible**: Compatible with Ahead-of-Time compilation and trimming
 - **Platform Configuration**: Supports WebView2 profiles, persistent storage paths, and many other platform-specific options
 - **Web APIs**: JavaScript execution, bidirectional messaging, cookie management, HTTP header interception
+- **Local content serving**: Fulfill requests with app-local bytes via `WebResourceRequestedEventArgs.SetResponse` and custom URI schemes (`CustomSchemes`)
 - **Authentication**: Web authentication broker for OAuth and web-based authentication
 - **Printing**: Print web content directly from the WebView
+
+## Local content / Hybrid
+
+To serve offline SPA or Blazor Hybrid content:
+
+1. Register a custom scheme (non-Windows) in `EnvironmentRequested`:
+
+```csharp
+webView.EnvironmentRequested += (_, e) => e.CustomSchemes.Add("app");
+```
+
+2. Fulfill matching requests:
+
+```csharp
+webView.WebResourceRequested += (_, e) =>
+{
+    if (e.Request.Uri.Scheme != "app") return;
+    e.SetResponse(
+        content: File.OpenRead("wwwroot/index.html"),
+        statusCode: 200,
+        reasonPhrase: "OK",
+        contentType: "text/html");
+};
+webView.Navigate(new Uri("app://0.0.0.0/"));
+```
+
+On Windows, Hybrid apps typically use `http://0.0.0.0/` with `SetResponse` instead of a custom scheme.
+
+For Blazor Hybrid, use the separate [`Avalonia.Controls.BlazorWebView`](../Avalonia.Controls.BlazorWebView/README.md) package.
 
 ## Quick Start
 

--- a/tests/Avalonia.Controls.WebView.Tests/NativeWebViewTests.cs
+++ b/tests/Avalonia.Controls.WebView.Tests/NativeWebViewTests.cs
@@ -139,4 +139,27 @@ public class NativeWebViewTests : HeadlessTestsBase
         Assert.False(wasDestroyed);
         Assert.NotNull(webView.TryGetPlatformHandle());
     }
+
+    [AvaloniaFact]
+    public void WebResourceRequestedEventArgs_SetResponse_Marks_Handled()
+    {
+        var args = new WebResourceRequestedEventArgs
+        {
+            Request = new WebViewWebResourceRequest
+            {
+                Uri = new Uri("app://0.0.0.0/index.html"),
+                Method = System.Net.Http.HttpMethod.Get,
+                Headers = new Avalonia.Controls.Utils.NativeHeadersCollection(
+                    Avalonia.Controls.Utils.DictionaryNativeHttpRequestHeaders.ImmutableInstance)
+            }
+        };
+
+        Assert.False(args.Handled);
+        using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes("<html></html>"));
+        args.SetResponse(stream, 200, "OK", "text/html");
+        Assert.True(args.Handled);
+        Assert.NotNull(args.Response);
+        Assert.Equal(200, args.Response!.StatusCode);
+        Assert.Equal("text/html", args.Response.ContentType);
+    }
 }


### PR DESCRIPTION
Introduce Avalonia.Controls.BlazorWebView with cross-platform resource interception backends, plus embedded wwwroot support so published apps need no on-disk wwwroot folder.