### PR TITLE
Allow forcing WebView1 over WebView2

### DIFF
--- a/src/Avalonia.Controls.WebView.Core/Platform/WindowsWebView2EnvironmentRequestedEventArgs.cs
+++ b/src/Avalonia.Controls.WebView.Core/Platform/WindowsWebView2EnvironmentRequestedEventArgs.cs
@@ -13,8 +13,9 @@ public sealed class WindowsWebView2EnvironmentRequestedEventArgs : WebViewEnviro
 
     /// <summary>
     /// Gets or sets a value indicating whether to prefer WebView1 instead of WebView2.
+    /// When set to true, the WebView1-based adapter is used even if the WebView2 runtime is available.
     /// </summary>
-    internal bool PreferWebView1Instead { get; set; }
+    public bool PreferWebView1Instead { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable offscreen composition mode.

--- a/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticationBroker.cs
@@ -147,9 +147,13 @@ namespace Avalonia.Xpf.Controls
             using var dialog = options.NativeWebDialogFactory?.Invoke() ?? DefaultFactory();
             dialog.EnvironmentRequested += (_, args) =>
             {
-                if (args is WindowsWebView2EnvironmentRequestedEventArgs webView2
-                    && options.NonPersistent)
-                    webView2.IsInPrivateModeEnabled = true;
+                if (args is WindowsWebView2EnvironmentRequestedEventArgs webView2)
+                {
+                    if (options.NonPersistent)
+                        webView2.IsInPrivateModeEnabled = true;
+                    if (options.PreferWebView1)
+                        webView2.PreferWebView1Instead = true;
+                }
                 else if (args is AppleWKWebViewEnvironmentRequestedEventArgs wkWebView
                          && options.NonPersistent)
                     wkWebView.NonPersistentDataStore = true;

--- a/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
+++ b/src/Avalonia.Controls.WebView/WebAuthenticatorOptions.cs
@@ -44,6 +44,12 @@ public record WebAuthenticatorOptions(Uri RequestUri, Uri RedirectUri)
     /// Options used when <see cref="Mode"/> is <see cref="WebAuthenticatorMode.Browser"/>.
     /// </summary>
     public BrowserOptions? BrowserOptions { get; init; }
+
+    /// <summary>
+    /// If true, forces the broker's WebView dialog to use WebView1 instead of WebView2 on Windows,
+    /// even if the WebView2 runtime is available. Has no effect on other platforms.
+    /// </summary>
+    public bool PreferWebView1 { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
There are some features and behaviours of the classic IE-based WebView1 that some applications may rely on that are not possible with WebView2, however it is not possible to force WV1 if WV2 is present on Windows.

The factory already honoured an internal `PreferWebView1Instead` flag on `WindowsWebView2EnvironmentRequestedEventArgs` to fall back to the legacy WebView1 engine, but the flag was unreachable, so callers had no way to opt out of WebView2 when its runtime was present.

Make `PreferWebView1Instead` public, mirroring the already-public `LinuxWpeWebViewEnvironmentRequestedEventArgs.PreferWebKitGtkInstead`, so it can be set from the `EnvironmentRequested` event surfaced by both `NativeWebView` and `NativeWebDialog`.

`WebAuthenticationBroker` drives its dialog internally and never raises that event, so also add a `PreferWebView1` option to `WebAuthenticatorOptions` and apply it next to the existing `NonPersistent` handling.